### PR TITLE
"Prettier" formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 150,
+  "brace_style": "collapse,preserve-inline"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,5 @@
 {
-  "trailingComma": "none",
-  "tabWidth": 2,
   "semi": false,
   "singleQuote": true,
-  "printWidth": 150,
-  "brace_style": "collapse,preserve-inline"
+  "printWidth": 150
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,20 +5,20 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from "vue";
-import pkg from "./../package.json";
-import QuantumDocument from "./ui/QuantumDocument.vue";
+import { defineComponent, ref } from 'vue'
+import pkg from './../package.json'
+import QuantumDocument from './ui/QuantumDocument.vue'
 
 export default defineComponent({
-  name: "App",
+  name: 'App',
   components: {
-    QuantumDocument,
+    QuantumDocument
   },
   setup(props, context) {
     if (import.meta.env.PROD) {
-      console.log(`${pkg.name} - ${pkg.version}`);
+      console.log(`${pkg.name} - ${pkg.version}`)
     }
-    return {};
-  },
-});
+    return {}
+  }
+})
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,13 +12,13 @@ import QuantumDocument from './ui/QuantumDocument.vue'
 export default defineComponent({
   name: 'App',
   components: {
-    QuantumDocument
+    QuantumDocument,
   },
   setup(props, context) {
     if (import.meta.env.PROD) {
       console.log(`${pkg.name} - ${pkg.version}`)
     }
     return {}
-  }
+  },
 })
 </script>

--- a/src/cas/cas-math.ts
+++ b/src/cas/cas-math.ts
@@ -1,46 +1,46 @@
-import { Expression } from "@cortex-js/compute-engine";
+import { Expression } from '@cortex-js/compute-engine'
 
 // TODO: Ask mathlive creator about how to best do stuff like this
 // TODO: Use stuff from here https://github.com/cortex-js/compute-engine/blob/main/src/common/utils.ts
 
 export function getGetterNames(expression: Expression) {
-  const getters = new Set<string>();
+  const getters = new Set<string>()
 
   if (!Array.isArray(expression)) {
-    if (typeof expression == "string") {
-      getters.add(expression);
+    if (typeof expression == 'string') {
+      getters.add(expression)
     }
   } else {
-    if (expression[0] == "Assign") {
-      extractGetters(expression[2]);
-    } else if (expression[0] == "Equal") {
-      extractGetters(expression[1]);
-    } else if (expression[0] == "Evaluate") {
-      extractGetters(expression[1]);
+    if (expression[0] == 'Assign') {
+      extractGetters(expression[2])
+    } else if (expression[0] == 'Equal') {
+      extractGetters(expression[1])
+    } else if (expression[0] == 'Evaluate') {
+      extractGetters(expression[1])
     } else {
-      extractGetters(expression);
+      extractGetters(expression)
     }
 
     function extractGetters(expression: Expression) {
       if (Array.isArray(expression)) {
-        const functionName = expression[0];
+        const functionName = expression[0]
         for (let i = 1; i < expression.length; i++) {
-          extractGetters(expression[i]);
+          extractGetters(expression[i])
         }
-      } else if (typeof expression === "string") {
-        getters.add(expression);
+      } else if (typeof expression === 'string') {
+        getters.add(expression)
       }
     }
   }
 
-  return getters;
+  return getters
 }
 
 export function getVariableNames(expression: Expression) {
-  const variables = new Set<string>();
-  if (Array.isArray(expression) && expression[0] == "Assign") {
+  const variables = new Set<string>()
+  if (Array.isArray(expression) && expression[0] == 'Assign') {
     // TODO: Handle variable arrays
-    variables.add(expression[1] as any);
+    variables.add(expression[1] as any)
   }
-  return variables;
+  return variables
 }

--- a/src/cas/cas.ts
+++ b/src/cas/cas.ts
@@ -1,33 +1,29 @@
-import type { Expression } from "@cortex-js/compute-engine";
-import { v4 as uuidv4 } from "uuid";
-import { usePyodide } from "./pyodide-cas";
+import type { Expression } from '@cortex-js/compute-engine'
+import { v4 as uuidv4 } from 'uuid'
+import { usePyodide } from './pyodide-cas'
 
 export interface UseCas {
-  executeCommand(command: CasCommand): void;
-  cancelCommand(command: CasCommand): void;
+  executeCommand(command: CasCommand): void
+  cancelCommand(command: CasCommand): void
 }
 
 export class CasCommand {
-  readonly id: string;
-  readonly gettersData: Map<string, any>;
-  readonly expression: Expression;
+  readonly id: string
+  readonly gettersData: Map<string, any>
+  readonly expression: Expression
 
-  readonly callback: (result: any) => void;
+  readonly callback: (result: any) => void
 
-  constructor(
-    gettersData: Map<string, any>,
-    expression: Expression,
-    callback: (result: any) => void
-  ) {
-    this.id = uuidv4();
-    this.gettersData = gettersData;
-    this.expression = expression;
-    this.callback = callback;
+  constructor(gettersData: Map<string, any>, expression: Expression, callback: (result: any) => void) {
+    this.id = uuidv4()
+    this.gettersData = gettersData
+    this.expression = expression
+    this.callback = callback
   }
 }
 
 export function useCas(): UseCas {
-  const cas = usePyodide();
+  const cas = usePyodide()
 
   /*function evaluateExpression(expression: any, gettersData: ReadonlyMap<string, any>, options?: {
     signal?: AbortController
@@ -36,16 +32,16 @@ export function useCas(): UseCas {
   }*/
 
   function executeCommand(command: CasCommand) {
-    console.log("Executing", command);
-    cas.executeCommand(command);
+    console.log('Executing', command)
+    cas.executeCommand(command)
   }
 
   function cancelCommand(command: CasCommand) {
-    cas.cancelCommand(command);
+    cas.cancelCommand(command)
   }
 
   return {
     executeCommand,
-    cancelCommand,
-  };
+    cancelCommand
+  }
 }

--- a/src/cas/pyodide-cas.ts
+++ b/src/cas/pyodide-cas.ts
@@ -1,130 +1,128 @@
-import type {} from "vite";
-import type { CasCommand } from "./cas";
-import { getGetterNames } from "./cas-math";
-import { format } from "@cortex-js/compute-engine";
+import type {} from 'vite'
+import type { CasCommand } from './cas'
+import { getGetterNames } from './cas-math'
+import { format } from '@cortex-js/compute-engine'
 
 export type WorkerMessage =
   | {
-      type: "python";
-      id: string;
+      type: 'python'
+      id: string
       data: {
-        [key: string]: any;
-      };
-      command: any;
+        [key: string]: any
+      }
+      command: any
     }
   | {
-      type: "expression";
-      id: string;
-      symbols: string[];
-      command: any;
-    };
+      type: 'expression'
+      id: string
+      symbols: string[]
+      command: any
+    }
 
 export type WorkerResponse =
   | {
-      type: "initialized";
+      type: 'initialized'
     }
   | {
-      type: "result";
-      id: string;
-      data: any;
+      type: 'result'
+      id: string
+      data: any
     }
   | {
-      type: "error";
-      id: string;
-      message: string;
-    };
+      type: 'error'
+      id: string
+      message: string
+    }
 
 // TODO: Split out the python converter and contribute it to mathlive/cortex-js?
 function usePythonConverter() {
-  const textEncoder = new TextEncoder();
-  const textDecoder = new TextDecoder();
+  const textEncoder = new TextEncoder()
+  const textDecoder = new TextDecoder()
 
   // TODO: Only convert names that actually need to be converted? Or use some standard encoding format?
   // Using 16 characters to encode utf-8. So, 2 chars per byte.
-  const charOffset = "A".charCodeAt(0);
+  const charOffset = 'A'.charCodeAt(0)
   function encodeName(name: string) {
-    const data = textEncoder.encode(name);
-    let output = "";
+    const data = textEncoder.encode(name)
+    let output = ''
     for (let i = 0; i < data.length; i++) {
-      const highBits = (data[i] >> 4) & 0x0f;
-      const lowBits = data[i] & 0x0f;
-      output +=
-        String.fromCharCode(highBits + charOffset) +
-        String.fromCharCode(lowBits + charOffset);
+      const highBits = (data[i] >> 4) & 0x0f
+      const lowBits = data[i] & 0x0f
+      output += String.fromCharCode(highBits + charOffset) + String.fromCharCode(lowBits + charOffset)
     }
 
-    return "_" + output;
+    return '_' + output
   }
 
   function decodeName(name: string) {
-    name = name.slice(1);
-    const output = new Uint8Array(name.length / 2);
+    name = name.slice(1)
+    const output = new Uint8Array(name.length / 2)
     for (let i = 0; i < name.length; i += 2) {
-      const highBits = name.charCodeAt(i) - charOffset;
-      const lowBits = name.charCodeAt(i + 1) - charOffset;
-      output[i / 2] = (highBits << 4) | lowBits;
+      const highBits = name.charCodeAt(i) - charOffset
+      const lowBits = name.charCodeAt(i + 1) - charOffset
+      output[i / 2] = (highBits << 4) | lowBits
     }
-    return textDecoder.decode(output);
+    return textDecoder.decode(output)
   }
 
   function decodeNames(expression: any) {
     if (Array.isArray(expression)) {
-      const functionName = expression[0];
-      const output = expression.slice();
+      const functionName = expression[0]
+      const output = expression.slice()
       for (let i = 1; i < expression.length; i++) {
-        output[i] = decodeNames(expression[i]);
+        output[i] = decodeNames(expression[i])
       }
-      return output;
-    } else if (typeof expression === "string") {
-      return decodeName(expression);
+      return output
+    } else if (typeof expression === 'string') {
+      return decodeName(expression)
     } else {
-      return expression;
+      return expression
     }
   }
 
   // TODO: Options (rational numbers)
   function expressionToPython(expression: any): string {
     if (Array.isArray(expression)) {
-      const functionName = expression[0];
-      let pythonFunctionName = "";
-      const parameters = [];
+      const functionName = expression[0]
+      let pythonFunctionName = ''
+      const parameters = []
 
-      if (functionName == "Add") {
-        pythonFunctionName = "sympy.Add";
-      } else if (functionName == "Subtract") {
-        pythonFunctionName = "Subtract"; // TODO: Negate the second parameter
-      } else if (functionName == "Negate") {
-        pythonFunctionName = "sympy.Mul";
-        parameters.push(-1);
-      } else if (functionName == "Multiply") {
-        pythonFunctionName = "sympy.Mul";
-      } else if (functionName == "Divide") {
-        pythonFunctionName = "Divide"; // TODO: Raise the second parameter to the power of -1
-      } else if (functionName == "Power") {
-        pythonFunctionName = "sympy.Pow";
-      } else if (functionName == "Sqrt") {
-        pythonFunctionName = "Sqrt"; // TODO: Replace with power
-      } else if (functionName == "EqualEqual") {
-        pythonFunctionName = "sympy.Eq";
+      if (functionName == 'Add') {
+        pythonFunctionName = 'sympy.Add'
+      } else if (functionName == 'Subtract') {
+        pythonFunctionName = 'Subtract' // TODO: Negate the second parameter
+      } else if (functionName == 'Negate') {
+        pythonFunctionName = 'sympy.Mul'
+        parameters.push(-1)
+      } else if (functionName == 'Multiply') {
+        pythonFunctionName = 'sympy.Mul'
+      } else if (functionName == 'Divide') {
+        pythonFunctionName = 'Divide' // TODO: Raise the second parameter to the power of -1
+      } else if (functionName == 'Power') {
+        pythonFunctionName = 'sympy.Pow'
+      } else if (functionName == 'Sqrt') {
+        pythonFunctionName = 'Sqrt' // TODO: Replace with power
+      } else if (functionName == 'EqualEqual') {
+        pythonFunctionName = 'sympy.Eq'
       } else {
-        pythonFunctionName = functionName;
+        pythonFunctionName = functionName
       }
       for (let i = 1; i < expression.length; i++) {
-        parameters.push(expressionToPython(expression[i]));
+        parameters.push(expressionToPython(expression[i]))
       }
-      return `${pythonFunctionName}(${parameters.join(",")})`;
-    } else if (typeof expression === "string") {
-      return encodeName(expression);
-    } else if (typeof expression === "number") {
-      return `sympy.Float(${expression})`;
+      return `${pythonFunctionName}(${parameters.join(',')})`
+    } else if (typeof expression === 'string') {
+      return encodeName(expression)
+    } else if (typeof expression === 'number') {
+      return `sympy.Float(${expression})`
     } else if (expression === null) {
-      return `None`;
+      return `None`
     } else if (expression.num !== undefined) {
-      return `sympy.Float(${expression.num})`;
+      return `sympy.Float(${expression.num})`
     } else {
       // TODO: Make sure to handle all cases (string, number, bool, array, object, ...)
-      console.warn("Unknown element type", { x: expression });
-      return "";
+      console.warn('Unknown element type', { x: expression })
+      return ''
     }
   }
 
@@ -137,24 +135,24 @@ function usePythonConverter() {
         format(expression, [
           // TODO: This has changed: https://cortexjs.io/compute-engine/guides/forms/
           // Sympy doesn't accept all operations https://docs.sympy.org/latest/tutorial/manipulation.html
-          "canonical-root",
-          "canonical-subtract",
-          "canonical-divide", // This one probably needs to be changed. The others seem fine
+          'canonical-root',
+          'canonical-subtract',
+          'canonical-divide' // This one probably needs to be changed. The others seem fine
         ])
-      ),
-  };
+      )
+  }
 }
 
 /**
  * Interface for a pyodide web worker or shared worker
  */
 interface PyodideWorker {
-  onmessage: ((ev: MessageEvent) => any) | null;
-  onmessageerror: ((ev: MessageEvent) => any) | null;
-  onerror: ((ev: ErrorEvent) => any) | null;
+  onmessage: ((ev: MessageEvent) => any) | null
+  onmessageerror: ((ev: MessageEvent) => any) | null
+  onerror: ((ev: ErrorEvent) => any) | null
 
-  postMessage(message: any, transfer: Transferable[]): void;
-  postMessage(message: any, options?: PostMessageOptions): void;
+  postMessage(message: any, transfer: Transferable[]): void
+  postMessage(message: any, options?: PostMessageOptions): void
 }
 
 /**
@@ -163,195 +161,175 @@ interface PyodideWorker {
  * @returns
  */
 function getOrCreateWorker(): Promise<PyodideWorker> {
-  const workerUrl = `${import.meta.env.BASE_URL}pyodide-worker.js`;
+  const workerUrl = `${import.meta.env.BASE_URL}pyodide-worker.js`
 
   if (import.meta.env.DEV && SharedWorker) {
     // Shared worker, survives all reloading as long as a tab is referencing it
     console.log(
-      `Creating pyodide worker... Slow? Try our new ${
-        new URL(
-          import.meta.env.BASE_URL + "pyodide-worker-keep-alive.html",
-          document.baseURI
-        ).href
-      }`
-    );
-    const sharedWorker = new SharedWorker(workerUrl);
+      `Creating pyodide worker... Slow? Try our new ${new URL(import.meta.env.BASE_URL + 'pyodide-worker-keep-alive.html', document.baseURI).href}`
+    )
+    const sharedWorker = new SharedWorker(workerUrl)
     const pyodideWorker: PyodideWorker = {
       onmessage: null,
       onmessageerror: null,
       onerror: null,
-      postMessage: function (
-        message: any,
-        options?: PostMessageOptions | Transferable[]
-      ) {
-        sharedWorker.port.postMessage(message, options as any);
-      },
-    };
+      postMessage: function (message: any, options?: PostMessageOptions | Transferable[]) {
+        sharedWorker.port.postMessage(message, options as any)
+      }
+    }
 
     return new Promise((resolve, reject) => {
       sharedWorker.port.onmessage = (e) => {
         sharedWorker.port.onmessage = function (e: MessageEvent) {
-          pyodideWorker.onmessage?.apply(this, [e]);
-        };
-        sharedWorker.port.onmessageerror = function (e: MessageEvent) {
-          pyodideWorker.onmessage?.apply(this, [e]);
-        };
-        sharedWorker.onerror = function (e: ErrorEvent) {
-          pyodideWorker.onerror?.apply(this, [e]);
-        };
-        const workerResponse = e.data;
-        if (workerResponse.type == "initialized") {
-          resolve(pyodideWorker);
-        } else {
-          reject(`Did not receive response of type initialized. ${e.data}`);
+          pyodideWorker.onmessage?.apply(this, [e])
         }
-      };
+        sharedWorker.port.onmessageerror = function (e: MessageEvent) {
+          pyodideWorker.onmessage?.apply(this, [e])
+        }
+        sharedWorker.onerror = function (e: ErrorEvent) {
+          pyodideWorker.onerror?.apply(this, [e])
+        }
+        const workerResponse = e.data
+        if (workerResponse.type == 'initialized') {
+          resolve(pyodideWorker)
+        } else {
+          reject(`Did not receive response of type initialized. ${e.data}`)
+        }
+      }
       sharedWorker.port.onmessageerror = (e) => {
-        reject(`Message error ${e}`);
-      };
+        reject(`Message error ${e}`)
+      }
       sharedWorker.onerror = (e) => {
-        reject(e.message);
-      };
-      sharedWorker.port.start();
-    });
+        reject(e.message)
+      }
+      sharedWorker.port.start()
+    })
   } else {
     // Normal web worker, survives vite hot reloading
-    let worker: Worker = (window as any)["pyodide-worker"];
+    let worker: Worker = (window as any)['pyodide-worker']
     if (worker) {
-      return Promise.resolve(worker);
+      return Promise.resolve(worker)
     } else {
-      console.log("Creating pyodide worker...");
-      worker = new Worker(workerUrl);
-      (window as any)["pyodide-worker"] = worker;
+      console.log('Creating pyodide worker...')
+      worker = new Worker(workerUrl)
+      ;(window as any)['pyodide-worker'] = worker
 
       return new Promise((resolve, reject) => {
         worker.onmessage = (e) => {
-          worker.onmessage = null;
-          worker.onmessageerror = null;
-          worker.onerror = null;
+          worker.onmessage = null
+          worker.onmessageerror = null
+          worker.onerror = null
 
-          const workerResponse = e.data;
-          if (workerResponse.type == "initialized") {
-            resolve(worker);
+          const workerResponse = e.data
+          if (workerResponse.type == 'initialized') {
+            resolve(worker)
           } else {
-            reject(`Did not receive response of type initialized. ${e.data}`);
+            reject(`Did not receive response of type initialized. ${e.data}`)
           }
-        };
+        }
         worker.onmessageerror = (e) => {
-          reject(`Message error ${e}`);
-        };
+          reject(`Message error ${e}`)
+        }
         worker.onerror = (e) => {
-          reject(e.message);
-        };
-      });
+          reject(e.message)
+        }
+      })
     }
   }
 }
 
 export function usePyodide() {
-  let worker: PyodideWorker | undefined;
-  const commandBuffer: WorkerMessage[] = [];
-  const { encodeName, decodeNames, expressionToPython } = usePythonConverter();
-  const commands = new Map<string, CasCommand>();
+  let worker: PyodideWorker | undefined
+  const commandBuffer: WorkerMessage[] = []
+  const { encodeName, decodeNames, expressionToPython } = usePythonConverter()
+  const commands = new Map<string, CasCommand>()
 
   getOrCreateWorker().then(
     (result) => {
-      console.log("Done creating worker!");
-      worker = result;
+      console.log('Done creating worker!')
+      worker = result
 
       worker.onmessage = (e) => {
-        let response = e.data as WorkerResponse;
-        console.log("Response", response);
+        let response = e.data as WorkerResponse
+        console.log('Response', response)
 
-        if (response.type == "result") {
-          const command = commands.get(response.id);
-          command?.callback(decodeNames(JSON.parse(response.data)));
-          commands.delete(response.id);
-        } else if (response.type == "error") {
-          console.warn(response);
-          commands.delete(response.id);
+        if (response.type == 'result') {
+          const command = commands.get(response.id)
+          command?.callback(decodeNames(JSON.parse(response.data)))
+          commands.delete(response.id)
+        } else if (response.type == 'error') {
+          console.warn(response)
+          commands.delete(response.id)
         } else {
-          console.error("Unknown response type", response);
+          console.error('Unknown response type', response)
         }
-      };
+      }
       worker.onerror = (e) => {
-        console.warn("Worker error", e);
-      };
+        console.warn('Worker error', e)
+      }
       worker.onmessageerror = (e) => {
-        console.error("Message error", e);
-      };
+        console.error('Message error', e)
+      }
 
-      commandBuffer.forEach((v) => sendCommand(v));
-      commandBuffer.length = 0;
+      commandBuffer.forEach((v) => sendCommand(v))
+      commandBuffer.length = 0
     },
     (error) => {
-      throw new Error(error);
+      throw new Error(error)
     }
-  );
+  )
 
   function executeCommand(command: CasCommand) {
-    commands.set(command.id, command);
+    commands.set(command.id, command)
 
-    const getterNames = getGetterNames(command.expression);
-    const symbolNames = Array.from(getterNames).map((key) => encodeName(key));
+    const getterNames = getGetterNames(command.expression)
+    const symbolNames = Array.from(getterNames).map((key) => encodeName(key))
 
     const substitutions = Array.from(command.gettersData.entries())
       .map(([key, value]) => `${encodeName(key)}:${expressionToPython(value)}`)
-      .join(",");
+      .join(',')
 
-    let pythonExpression = "";
+    let pythonExpression = ''
     // Only parse the expression if there is an "Equal" or "Solve" or "Apply" at the root
-    if (command.expression[0] == "Equal") {
+    if (command.expression[0] == 'Equal') {
       // TODO: If the expression is only a single getter or something simple, don't call the CAS
-      pythonExpression = `${expressionToPython(
-        command.expression[1]
-      )}\n\t.subs({${substitutions}})\n\t.evalf()`;
-    } else if (command.expression[0] == "Evaluate") {
-      if ((command.expression[2] + "").toLowerCase() == "solve") {
-        let variablesToSolveFor: string[] = [];
+      pythonExpression = `${expressionToPython(command.expression[1])}\n\t.subs({${substitutions}})\n\t.evalf()`
+    } else if (command.expression[0] == 'Evaluate') {
+      if ((command.expression[2] + '').toLowerCase() == 'solve') {
+        let variablesToSolveFor: string[] = []
         getterNames.forEach((getterName) => {
           if (!command.gettersData.has(getterName)) {
-            variablesToSolveFor.push(getterName);
+            variablesToSolveFor.push(getterName)
           }
-        });
+        })
         if (variablesToSolveFor.length !== 1) {
-          console.error(
-            "Expected one variable to solve for",
-            variablesToSolveFor
-          );
+          console.error('Expected one variable to solve for', variablesToSolveFor)
         }
 
-        const innerExpression = command.expression[1];
-        if (
-          Array.isArray(innerExpression) &&
-          innerExpression[0] == "EqualEqual"
-        ) {
+        const innerExpression = command.expression[1]
+        if (Array.isArray(innerExpression) && innerExpression[0] == 'EqualEqual') {
           // TODO: Use recommended solver instead of the generic one
 
-          pythonExpression = `sympy.solvers.solve(\n\t${expressionToPython(
-            innerExpression
-          )}\n\t\t.subs({${substitutions}})\n)`;
+          pythonExpression = `sympy.solvers.solve(\n\t${expressionToPython(innerExpression)}\n\t\t.subs({${substitutions}})\n)`
         } else {
-          console.error("Expected inner expression to be EqualEqual (==)");
+          console.error('Expected inner expression to be EqualEqual (==)')
         }
       } else {
-        pythonExpression = `${expressionToPython(
-          command.expression[1]
-        )}\n\t.subs({${substitutions}})\n\t.evalf()`;
+        pythonExpression = `${expressionToPython(command.expression[1])}\n\t.subs({${substitutions}})\n\t.evalf()`
       }
     } else {
-      commands.delete(command.id);
-      return;
+      commands.delete(command.id)
+      return
     }
 
-    console.log("Python expression", pythonExpression);
+    console.log('Python expression', pythonExpression)
     sendCommand({
-      type: "expression",
+      type: 'expression',
       id: command.id,
       data: {},
       symbols: symbolNames,
-      command: pythonExpression,
-    } as WorkerMessage);
+      command: pythonExpression
+    } as WorkerMessage)
   }
 
   function cancelCommand(command: CasCommand) {
@@ -362,14 +340,14 @@ export function usePyodide() {
 
   function sendCommand(command: WorkerMessage) {
     if (!worker) {
-      commandBuffer.push(command);
+      commandBuffer.push(command)
     } else {
-      worker.postMessage(command);
+      worker.postMessage(command)
     }
   }
 
   return {
     executeCommand,
-    cancelCommand,
-  };
+    cancelCommand
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
-import { createApp } from "vue";
-import App from "./App.vue";
-import "./index.css";
+import { createApp } from 'vue'
+import App from './App.vue'
+import './index.css'
 
-createApp(App).mount("#app");
+createApp(App).mount('#app')

--- a/src/model/array-utils.ts
+++ b/src/model/array-utils.ts
@@ -41,5 +41,5 @@ export default {
     } else {
       return false
     }
-  }
+  },
 }

--- a/src/model/array-utils.ts
+++ b/src/model/array-utils.ts
@@ -4,45 +4,42 @@ export default {
    * @param array Target array
    * @param compareFunction Comparison function, should compare arrayElement to the new value
    */
-  getBinaryInsertIndex: function <T>(
-    array: T[],
-    compareFunction: (arrayElement: T) => number
-  ): { index: number; itemExists: boolean } {
+  getBinaryInsertIndex: function <T>(array: T[], compareFunction: (arrayElement: T) => number): { index: number; itemExists: boolean } {
     // https://stackoverflow.com/a/29018745
-    let low = 0;
-    let high = array.length - 1;
+    let low = 0
+    let high = array.length - 1
     while (low <= high) {
-      let middle = low + Math.floor((high - low) / 2);
-      let comparison = compareFunction(array[middle]);
+      let middle = low + Math.floor((high - low) / 2)
+      let comparison = compareFunction(array[middle])
       if (comparison < 0) {
-        low = middle + 1;
+        low = middle + 1
       } else if (comparison > 0) {
-        high = middle - 1;
+        high = middle - 1
       } else {
-        return { index: middle, itemExists: true };
+        return { index: middle, itemExists: true }
       }
     }
 
-    return { index: low, itemExists: false };
+    return { index: low, itemExists: false }
   },
 
   /**
    * Gets an element or undefined if the element does not exist
    */
   tryGetElement: function <T>(array: T[], index: number) {
-    return index >= 0 && index < array.length ? array[index] : undefined;
+    return index >= 0 && index < array.length ? array[index] : undefined
   },
 
   /**
    * Removes an element from an array
    */
   remove: function <T>(array: T[], element: T) {
-    const index = array.indexOf(element);
+    const index = array.indexOf(element)
     if (index >= 0) {
-      array.splice(index, 1);
-      return true;
+      array.splice(index, 1)
+      return true
     } else {
-      return false;
+      return false
     }
-  },
-};
+  }
+}

--- a/src/model/assert.ts
+++ b/src/model/assert.ts
@@ -1,5 +1,5 @@
 export function assert(condition: any, msg?: string): asserts condition {
   if (!condition) {
-    throw new Error(msg);
+    throw new Error(msg)
   }
 }

--- a/src/model/cas.ts
+++ b/src/model/cas.ts
@@ -1,8 +1,8 @@
-import { useCas } from "../cas/cas";
+import { useCas } from '../cas/cas'
 
 /**
  * The global computer algebra system entrypoint.
  * Internally, the useCas function can send the expression to different systems.
  * For example, a simple addition can be done in Javascript, while a partial differential equation can be sent to Sympy.
  */
-export const cas = useCas();
+export const cas = useCas()

--- a/src/model/document/document-element.ts
+++ b/src/model/document/document-element.ts
@@ -1,50 +1,47 @@
-import { Ref } from "vue";
-import { Vector2 } from "../vectors";
-import type { UseScopeElement } from "./elements/scope-element";
+import { Ref } from 'vue'
+import { Vector2 } from '../vectors'
+import type { UseScopeElement } from './elements/scope-element'
 
 /**
  * An element in the document.
  * Specialized elements will extend this interface and add their own properties.
  */
 export interface UseQuantumElement {
-  readonly id: string;
-  readonly typeName: string;
+  readonly id: string
+  readonly typeName: string
 
-  position: Ref<Vector2>;
-  size: Ref<Vector2>; // can include a fractional part
-  resizeable: Ref<boolean>;
-  selected: Ref<boolean>;
-  focused: Ref<boolean>;
-  scope: Ref<UseScopeElement | undefined>;
+  position: Ref<Vector2>
+  size: Ref<Vector2> // can include a fractional part
+  resizeable: Ref<boolean>
+  selected: Ref<boolean>
+  focused: Ref<boolean>
+  scope: Ref<UseScopeElement | undefined>
 
-  setPosition(value: Vector2): void;
-  setSize(value: Vector2): void;
-  setSelected(value: boolean): void;
-  setFocused(value: boolean): void;
-  setScope(value: UseScopeElement | undefined): void;
+  setPosition(value: Vector2): void
+  setSize(value: Vector2): void
+  setSelected(value: boolean): void
+  setFocused(value: boolean): void
+  setScope(value: UseScopeElement | undefined): void
 }
 
 /**
  * Parameters to pass when creating an element
  */
 export interface QuantumElementCreationOptions {
-  position?: Vector2;
-  resizeable?: boolean;
+  position?: Vector2
+  resizeable?: boolean
 }
 
 // This type is used to say "an element with the following name exists"
 // It's pretty complicated, maybe it could be simplified
-export type QuantumElementType<
-  T extends UseQuantumElement,
-  U extends string
-> = {
-  readonly typeName: U;
+export type QuantumElementType<T extends UseQuantumElement, U extends string> = {
+  readonly typeName: U
   documentType: {
     [K in U]: {
-      readonly typeName: K;
-      useElement: (block: UseQuantumElement) => T;
-      serializeElement(element: T): string;
-      deserializeElement(data: string): T;
-    };
-  };
-};
+      readonly typeName: K
+      useElement: (block: UseQuantumElement) => T
+      serializeElement(element: T): string
+      deserializeElement(data: string): T
+    }
+  }
+}

--- a/src/model/document/document.ts
+++ b/src/model/document/document.ts
@@ -89,7 +89,7 @@ function useElementList() {
         elements.splice(index, 0, element)
       },
       {
-        immediate: true
+        immediate: true,
       }
     )
 
@@ -121,7 +121,7 @@ function useElementList() {
   return {
     elements,
     watchElement,
-    getElementAt
+    getElementAt,
   }
 }
 
@@ -139,7 +139,7 @@ function useElementSelection() {
         }
       },
       {
-        immediate: true
+        immediate: true,
       }
     )
 
@@ -157,7 +157,7 @@ function useElementSelection() {
   return {
     selectedElements,
     setSelection,
-    watchElement
+    watchElement,
   }
 }
 
@@ -180,7 +180,7 @@ function useElementFocus() {
         }
       },
       {
-        immediate: true
+        immediate: true,
       }
     )
 
@@ -201,7 +201,7 @@ function useElementFocus() {
   return {
     focusedElement,
     watchElement,
-    setFocus
+    setFocus,
   }
 }
 
@@ -246,7 +246,7 @@ function useQuantumElement(
     setSize,
     setSelected,
     setFocused,
-    setScope
+    setScope,
   }
 }
 
@@ -263,7 +263,7 @@ export function useDocument<TElements extends QuantumDocumentElementTypes>(eleme
   const elementFocus = useElementFocus()
 
   const rootScope = createElement(ScopeElementType.typeName, {
-    position: Vector2.zero
+    position: Vector2.zero,
   }) // TODO: Scope size:
 
   function createElement<T extends keyof TElements>(typeName: T, options: QuantumElementCreationOptions): ReturnType<TElements[T]['useElement']> {
@@ -316,6 +316,6 @@ variableManager: shallowReadonly(
     getElementAt: elementList.getElementAt,
     getElementById,
     setSelection: elementSelection.setSelection,
-    setFocus: elementFocus.setFocus
+    setFocus: elementFocus.setFocus,
   }
 }

--- a/src/model/document/document.ts
+++ b/src/model/document/document.ts
@@ -1,191 +1,168 @@
 // Not recursive! The expression tree on the other hand will be recursive.
 
-import {
-  UseQuantumElement,
-  QuantumElementCreationOptions,
-  QuantumElementType,
-} from "./document-element";
-import { Vector2 } from "../vectors";
-import { readonly, shallowReactive, shallowRef, ref, watch } from "vue";
-import { v4 as uuidv4 } from "uuid";
-import arrayUtils from "../array-utils";
-import { UseScopeElement, ScopeElementType } from "./elements/scope-element";
+import { UseQuantumElement, QuantumElementCreationOptions, QuantumElementType } from './document-element'
+import { Vector2 } from '../vectors'
+import { readonly, shallowReactive, shallowRef, ref, watch } from 'vue'
+import { v4 as uuidv4 } from 'uuid'
+import arrayUtils from '../array-utils'
+import { UseScopeElement, ScopeElementType } from './elements/scope-element'
 
-export type QuantumDocumentElementTypes = QuantumElementType<
-  UseQuantumElement,
-  string
->["documentType"] &
-  typeof ScopeElementType.documentType;
+export type QuantumDocumentElementTypes = QuantumElementType<UseQuantumElement, string>['documentType'] & typeof ScopeElementType.documentType
 
 // type NameToElementType<T extends {useElement: (...args: any) => UseQuantumElement}> = T extends {useElement: (...args: any) => infer R} ? R : any;
 
 /**
  * A top level document, containing a list of elements.
  */
-export interface UseQuantumDocument<
-  TElements extends QuantumDocumentElementTypes
-> {
+export interface UseQuantumDocument<TElements extends QuantumDocumentElementTypes> {
   /**
    * How large the grid cells are, in pixels
    */
-  readonly gridCellSize: Readonly<Vector2>;
+  readonly gridCellSize: Readonly<Vector2>
 
   /**
    * Which elements the document contains
    */
-  readonly elementTypes: Readonly<TElements>;
+  readonly elementTypes: Readonly<TElements>
 
   /**
    * Shallow reactive elements array
    */
-  readonly elements: ReadonlyArray<UseQuantumElement>;
+  readonly elements: ReadonlyArray<UseQuantumElement>
 
   /**
    * Creates an element with a given type
    * @param typeName Element type name
    * @param options Element options
    */
-  createElement<T extends keyof TElements>(
-    typeName: T,
-    options: QuantumElementCreationOptions
-  ): ReturnType<TElements[T]["useElement"]>;
+  createElement<T extends keyof TElements>(typeName: T, options: QuantumElementCreationOptions): ReturnType<TElements[T]['useElement']>
 
   /**
    * Deletes an element
    * @param element Element
    */
-  deleteElement(element: UseQuantumElement): void;
+  deleteElement(element: UseQuantumElement): void
 
   /**
    * Gets the element at a given position
    * @param position Position
    */
-  getElementAt(position: Vector2): UseQuantumElement | undefined;
+  getElementAt(position: Vector2): UseQuantumElement | undefined
 
   /**
    * Gets the element with the given id
    * @param id Element id
    * @param type Element type name
    */
-  getElementById<T extends keyof TElements>(
-    id: string,
-    typeName: T
-  ): ReturnType<TElements[T]["useElement"]> | undefined;
+  getElementById<T extends keyof TElements>(id: string, typeName: T): ReturnType<TElements[T]['useElement']> | undefined
 
   /**
    * Set the element selection
    * @param elements Elements to select
    */
-  setSelection(...elements: UseQuantumElement[]): void;
+  setSelection(...elements: UseQuantumElement[]): void
 
   /**
    * Sets the element focus
    */
-  setFocus(element?: UseQuantumElement): void;
+  setFocus(element?: UseQuantumElement): void
 }
 
 function useElementList() {
-  const elements = shallowReactive<UseQuantumElement[]>([]);
+  const elements = shallowReactive<UseQuantumElement[]>([])
 
   function watchElement(element: UseQuantumElement) {
     const stopHandle = watch(
       element.position,
       (value, oldValue) => {
-        let { index } = arrayUtils.getBinaryInsertIndex(elements, (a) =>
-          a.position.value.compareTo(value)
-        );
+        let { index } = arrayUtils.getBinaryInsertIndex(elements, (a) => a.position.value.compareTo(value))
 
         // TODO: A block added callback
         // TODO: Refactor the scope setting
-        const prev = arrayUtils.tryGetElement(elements, index - 1);
+        const prev = arrayUtils.tryGetElement(elements, index - 1)
         if (prev?.typeName == ScopeElementType.typeName) {
-          element.setScope(prev as UseScopeElement);
+          element.setScope(prev as UseScopeElement)
         } else {
-          element.setScope(prev?.scope.value);
+          element.setScope(prev?.scope.value)
         }
 
-        elements.splice(index, 0, element);
+        elements.splice(index, 0, element)
       },
       {
-        immediate: true,
+        immediate: true
       }
-    );
+    )
 
     return () => {
-      stopHandle();
-      element.setScope(undefined); // TODO: Refactor the scope setting
-      const index = elements.indexOf(element);
+      stopHandle()
+      element.setScope(undefined) // TODO: Refactor the scope setting
+      const index = elements.indexOf(element)
       if (index >= 0) {
-        elements.splice(index, 1);
+        elements.splice(index, 1)
       }
-    };
+    }
   }
 
   function getElementAt(position: Vector2) {
-    const posX = position.x;
-    const posY = position.y;
+    const posX = position.x
+    const posY = position.y
     for (let i = elements.length - 1; i >= 0; i--) {
-      let element = elements[i];
-      let x = element.position.value.x;
-      let y = element.position.value.y;
-      if (
-        y <= posY &&
-        posY <= y + element.size.value.y &&
-        x <= posX &&
-        posX <= x + element.size.value.x
-      ) {
-        return element;
+      let element = elements[i]
+      let x = element.position.value.x
+      let y = element.position.value.y
+      if (y <= posY && posY <= y + element.size.value.y && x <= posX && posX <= x + element.size.value.x) {
+        return element
       }
     }
 
-    return undefined;
+    return undefined
   }
 
   return {
     elements,
     watchElement,
-    getElementAt,
-  };
+    getElementAt
+  }
 }
 
 function useElementSelection() {
-  const selectedElements = shallowReactive<Set<UseQuantumElement>>(new Set());
+  const selectedElements = shallowReactive<Set<UseQuantumElement>>(new Set())
 
   function watchElement(element: UseQuantumElement) {
     const stopHandle = watch(
       element.selected,
       (value) => {
         if (value) {
-          selectedElements.add(element);
+          selectedElements.add(element)
         } else {
-          selectedElements.delete(element);
+          selectedElements.delete(element)
         }
       },
       {
-        immediate: true,
+        immediate: true
       }
-    );
+    )
 
     return () => {
-      element.selected.value = false;
-      stopHandle();
-    };
+      element.selected.value = false
+      stopHandle()
+    }
   }
 
   function setSelection(...elements: UseQuantumElement[]) {
-    selectedElements.forEach((e) => e.setSelected(false));
-    elements.forEach((e) => e.setSelected(true));
+    selectedElements.forEach((e) => e.setSelected(false))
+    elements.forEach((e) => e.setSelected(true))
   }
 
   return {
     selectedElements,
     setSelection,
-    watchElement,
-  };
+    watchElement
+  }
 }
 
 function useElementFocus() {
-  const focusedElement = shallowRef<UseQuantumElement>();
+  const focusedElement = shallowRef<UseQuantumElement>()
 
   function watchElement(element: UseQuantumElement) {
     const stopHandle = watch(
@@ -193,39 +170,39 @@ function useElementFocus() {
       (value) => {
         if (value) {
           if (focusedElement.value?.focused) {
-            focusedElement.value.setFocused(false);
+            focusedElement.value.setFocused(false)
           }
-          focusedElement.value = element;
+          focusedElement.value = element
         } else {
           if (focusedElement.value == element) {
-            focusedElement.value = undefined;
+            focusedElement.value = undefined
           }
         }
       },
       {
-        immediate: true,
+        immediate: true
       }
-    );
+    )
 
     return () => {
-      element.focused.value = false;
-      stopHandle();
-    };
+      element.focused.value = false
+      stopHandle()
+    }
   }
 
   function setFocus(element?: UseQuantumElement) {
     if (element) {
-      element.setFocused(true);
+      element.setFocused(true)
     } else {
-      focusedElement.value?.setFocused(false);
+      focusedElement.value?.setFocused(false)
     }
   }
 
   return {
     focusedElement,
     watchElement,
-    setFocus,
-  };
+    setFocus
+  }
 }
 
 function useQuantumElement(
@@ -233,27 +210,27 @@ function useQuantumElement(
   options: QuantumElementCreationOptions
   /* Here internal document stuff can be passed */
 ): UseQuantumElement {
-  const position = ref(options.position ?? Vector2.zero);
-  const size = ref(new Vector2(5, 2)); // TODO: Size stuff
-  const resizeable = ref(options.resizeable ?? false);
-  const selected = ref(false);
-  const focused = ref(false);
-  const scope = ref<UseScopeElement>();
+  const position = ref(options.position ?? Vector2.zero)
+  const size = ref(new Vector2(5, 2)) // TODO: Size stuff
+  const resizeable = ref(options.resizeable ?? false)
+  const selected = ref(false)
+  const focused = ref(false)
+  const scope = ref<UseScopeElement>()
 
   function setPosition(value: Vector2) {
-    position.value = value;
+    position.value = value
   }
   function setSize(value: Vector2) {
-    size.value = value;
+    size.value = value
   }
   function setSelected(value: boolean) {
-    selected.value = value;
+    selected.value = value
   }
   function setFocused(value: boolean) {
-    focused.value = value;
+    focused.value = value
   }
   function setScope(value: UseScopeElement | undefined) {
-    scope.value = value;
+    scope.value = value
   }
 
   return {
@@ -269,47 +246,36 @@ function useQuantumElement(
     setSize,
     setSelected,
     setFocused,
-    setScope,
-  };
+    setScope
+  }
 }
 
 /**
  * Create a document
  * @param elementTypes Element types in the document
  */
-export function useDocument<TElements extends QuantumDocumentElementTypes>(
-  elementTypes: TElements
-): UseQuantumDocument<TElements> {
-  const gridCellSize = readonly(new Vector2(20, 20));
+export function useDocument<TElements extends QuantumDocumentElementTypes>(elementTypes: TElements): UseQuantumDocument<TElements> {
+  const gridCellSize = readonly(new Vector2(20, 20))
 
-  const elementRemoveCallbacks = new Map<string, () => void>();
-  const elementList = useElementList();
-  const elementSelection = useElementSelection();
-  const elementFocus = useElementFocus();
+  const elementRemoveCallbacks = new Map<string, () => void>()
+  const elementList = useElementList()
+  const elementSelection = useElementSelection()
+  const elementFocus = useElementFocus()
 
   const rootScope = createElement(ScopeElementType.typeName, {
-    position: Vector2.zero,
-  }); // TODO: Scope size:
+    position: Vector2.zero
+  }) // TODO: Scope size:
 
-  function createElement<T extends keyof TElements>(
-    typeName: T,
-    options: QuantumElementCreationOptions
-  ): ReturnType<TElements[T]["useElement"]> {
-    let elementType = elementTypes[typeName];
-    if (!elementType) throw new Error(`Unknown element type ${typeName}`);
+  function createElement<T extends keyof TElements>(typeName: T, options: QuantumElementCreationOptions): ReturnType<TElements[T]['useElement']> {
+    let elementType = elementTypes[typeName]
+    if (!elementType) throw new Error(`Unknown element type ${typeName}`)
 
-    const element = elementType.useElement(
-      useQuantumElement("" + typeName, options)
-    ) as ReturnType<TElements[T]["useElement"]>;
+    const element = elementType.useElement(useQuantumElement('' + typeName, options)) as ReturnType<TElements[T]['useElement']>
 
-    let stopHandles = [
-      elementList.watchElement(element),
-      elementSelection.watchElement(element),
-      elementFocus.watchElement(element),
-    ];
+    let stopHandles = [elementList.watchElement(element), elementSelection.watchElement(element), elementFocus.watchElement(element)]
     elementRemoveCallbacks.set(element.id, () => {
-      stopHandles.forEach((stopHandle) => stopHandle());
-    });
+      stopHandles.forEach((stopHandle) => stopHandle())
+    })
 
     /* When moving a block, we know its target index. Therefore we know what neighbors the block has after insertion. (And the "scope start/getters" and "scope end/setters" nicely guarantee that the neighbor stuff will always be correct. ((If we do not have getters in the tree, in case of a getter, we could increment the index until we find a setter but then the whole blocks stuff becomes relevant and honestly, that's not fun anymore)))
 ^ Therefore, we can totally keep track of which scope every block is in. It's super cheap. (Block --> scope)
@@ -320,30 +286,25 @@ variableManager: shallowReadonly(
       ),*/
 
     // Weird, Typescript doesn't like whatever I cooked up
-    return element;
+    return element
   }
 
   function deleteElement(element: UseQuantumElement) {
-    let removeCallback = elementRemoveCallbacks.get(element.id);
+    let removeCallback = elementRemoveCallbacks.get(element.id)
     if (removeCallback) {
-      removeCallback();
-      elementRemoveCallbacks.delete(element.id);
+      removeCallback()
+      elementRemoveCallbacks.delete(element.id)
     }
   }
 
-  function getElementById<T extends keyof TElements>(
-    id: string,
-    typeName?: T
-  ): ReturnType<TElements[T]["useElement"]> | undefined {
-    let element = elementList.elements.find((e) => e.id == id);
+  function getElementById<T extends keyof TElements>(id: string, typeName?: T): ReturnType<TElements[T]['useElement']> | undefined {
+    let element = elementList.elements.find((e) => e.id == id)
     if (element && typeName && element.typeName != typeName) {
-      throw new Error(
-        `Wrong type, passed ${typeName} but element has ${element.typeName}`
-      );
+      throw new Error(`Wrong type, passed ${typeName} but element has ${element.typeName}`)
     }
 
     // Yeah, Typescript really does dislike this XD
-    return element as any;
+    return element as any
   }
 
   return {
@@ -355,6 +316,6 @@ variableManager: shallowReadonly(
     getElementAt: elementList.getElementAt,
     getElementById,
     setSelection: elementSelection.setSelection,
-    setFocus: elementFocus.setFocus,
-  };
+    setFocus: elementFocus.setFocus
+  }
 }

--- a/src/model/document/elements/expression-element.ts
+++ b/src/model/document/elements/expression-element.ts
@@ -273,7 +273,7 @@ function useExpressionElement(block: UseQuantumElement): UseExpressionElement {
     getters,
     variables,
     expression,
-    inputExpression
+    inputExpression,
   }
 }
 
@@ -292,7 +292,7 @@ export const ExpressionElementType: QuantumElementType<UseExpressionElement, typ
       typeName: ElementType,
       useElement: useExpressionElement,
       serializeElement: serializeElement,
-      deserializeElement: deserializeElement
-    }
-  }
+      deserializeElement: deserializeElement,
+    },
+  },
 }

--- a/src/model/document/elements/expression-element.ts
+++ b/src/model/document/elements/expression-element.ts
@@ -1,195 +1,186 @@
-import { UseQuantumElement, QuantumElementType } from "../document-element";
-import {
-  ref,
-  Ref,
-  watch,
-  reactive,
-  shallowRef,
-  computed,
-  watchEffect,
-  shallowReactive,
-} from "vue";
-import { UseScopedVariable, UseScopedGetter } from "./scope-element";
-import { cas } from "../../cas";
-import { assert } from "../../assert";
-import { CasCommand } from "../../../cas/cas";
-import { getGetterNames, getVariableNames } from "../../../cas/cas-math";
-import { Expression, match, substitute } from "@cortex-js/compute-engine";
+import { UseQuantumElement, QuantumElementType } from '../document-element'
+import { ref, Ref, watch, reactive, shallowRef, computed, watchEffect, shallowReactive } from 'vue'
+import { UseScopedVariable, UseScopedGetter } from './scope-element'
+import { cas } from '../../cas'
+import { assert } from '../../assert'
+import { CasCommand } from '../../../cas/cas'
+import { getGetterNames, getVariableNames } from '../../../cas/cas-math'
+import { Expression, match, substitute } from '@cortex-js/compute-engine'
 
-export const ElementType = "expression-element";
+export const ElementType = 'expression-element'
 
 export interface UseExpressionElement extends UseQuantumElement {
-  getters: ReadonlyMap<string, UseScopedGetter>;
-  variables: ReadonlyMap<string, UseScopedVariable>;
-  expression: Ref<Expression>;
+  getters: ReadonlyMap<string, UseScopedGetter>
+  variables: ReadonlyMap<string, UseScopedVariable>
+  expression: Ref<Expression>
   /**
    * User expression input
    * @param value Expression that the user typed
    */
-  inputExpression(value: Expression): void;
+  inputExpression(value: Expression): void
 }
 
 function addPlaceholders(expression: Expression) {
   // TODO: Use patterns and replacements https://cortexjs.io/compute-engine/guides/patterns-and-rules/
 
   if (Array.isArray(expression)) {
-    const functionName = expression[0];
-    const output = expression.slice();
-    if (functionName == "Equal") {
-      output[1] = addPlaceholders(expression[1]);
-      output[2] = ["\\mathinner", ["Missing", ""]];
-    } else if (functionName == "Evaluate") {
-      output[1] = addPlaceholders(expression[1]);
-      output[3] = ["\\mathinner", ["Missing", ""]];
+    const functionName = expression[0]
+    const output = expression.slice()
+    if (functionName == 'Equal') {
+      output[1] = addPlaceholders(expression[1])
+      output[2] = ['\\mathinner', ['Missing', '']]
+    } else if (functionName == 'Evaluate') {
+      output[1] = addPlaceholders(expression[1])
+      output[3] = ['\\mathinner', ['Missing', '']]
     } else {
       for (let i = 1; i < expression.length; i++) {
-        output[i] = addPlaceholders(expression[i]);
+        output[i] = addPlaceholders(expression[i])
       }
     }
-    return output;
+    return output
   } else {
-    return expression;
+    return expression
   }
 }
 
 function useExpressionElement(block: UseQuantumElement): UseExpressionElement {
-  const expression = shallowRef();
-  const getters = shallowReactive(new Map<string, UseScopedGetter>());
-  const variables = shallowReactive(new Map<string, UseScopedVariable>());
-  const runningCasExpression: Ref<CasCommand | undefined> = shallowRef();
-  const blockPosition = computed(() => block.position.value);
+  const expression = shallowRef()
+  const getters = shallowReactive(new Map<string, UseScopedGetter>())
+  const variables = shallowReactive(new Map<string, UseScopedVariable>())
+  const runningCasExpression: Ref<CasCommand | undefined> = shallowRef()
+  const blockPosition = computed(() => block.position.value)
 
   function setExpression(value: Expression) {
-    expression.value = value;
+    expression.value = value
   }
 
   function setGetters(getterNames: ReadonlySet<string>) {
-    const namesToAdd = new Set<string>(getterNames);
+    const namesToAdd = new Set<string>(getterNames)
     getters.forEach((getter, variableName) => {
       if (!namesToAdd.has(variableName)) {
-        getter.remove();
-        getters.delete(variableName);
+        getter.remove()
+        getters.delete(variableName)
       } else {
-        namesToAdd.delete(variableName);
+        namesToAdd.delete(variableName)
       }
-    });
+    })
 
     if (namesToAdd.size > 0) {
-      const scope = block.scope.value;
-      assert(scope, "Expected the block to have a scope");
+      const scope = block.scope.value
+      assert(scope, 'Expected the block to have a scope')
       namesToAdd.forEach((variableName) => {
-        const newGetter = scope.addGetter(variableName, blockPosition);
+        const newGetter = scope.addGetter(variableName, blockPosition)
         watch(newGetter.data, (value) => {
-          clearVariableValues();
-          clearPlaceholders();
-          if (value !== undefined && value !== null) evaluateLater();
-        });
-        getters.set(variableName, newGetter);
-      });
+          clearVariableValues()
+          clearPlaceholders()
+          if (value !== undefined && value !== null) evaluateLater()
+        })
+        getters.set(variableName, newGetter)
+      })
     }
   }
 
   function setVariables(variableNames: ReadonlySet<string>) {
-    const namesToAdd = new Set<string>(variableNames);
+    const namesToAdd = new Set<string>(variableNames)
 
     variables.forEach((variable, variableName) => {
       if (!namesToAdd.has(variableName)) {
-        variable.remove();
-        variables.delete(variableName);
+        variable.remove()
+        variables.delete(variableName)
       } else {
-        namesToAdd.delete(variableName);
+        namesToAdd.delete(variableName)
       }
-    });
+    })
     if (namesToAdd.size > 0) {
-      const scope = block.scope.value;
-      assert(scope, "Expected the block to have a scope");
+      const scope = block.scope.value
+      assert(scope, 'Expected the block to have a scope')
       namesToAdd.forEach((variableName) => {
-        const newVariable = scope.addVariable(variableName, blockPosition);
-        variables.set(variableName, newVariable);
-      });
+        const newVariable = scope.addVariable(variableName, blockPosition)
+        variables.set(variableName, newVariable)
+      })
     }
   }
 
   function clearVariableValues() {
-    variables.forEach((v) => v.setData(null));
+    variables.forEach((v) => v.setData(null))
   }
 
   function clearPlaceholders() {
     // TODO: Reduce flashing (make this slightly delayed or something)
     function clearPlaceholders(expression: Expression) {
       if (Array.isArray(expression)) {
-        const functionName = expression[0];
-        const output = expression.slice();
-        if (functionName == "Equal") {
-          output[1] = addPlaceholders(expression[1]);
-          output[2] = ["\\mathinner", ["Missing", ""]];
-        } else if (functionName == "Evaluate") {
-          output[1] = addPlaceholders(expression[1]);
-          output[3] = ["\\mathinner", ["Missing", ""]];
+        const functionName = expression[0]
+        const output = expression.slice()
+        if (functionName == 'Equal') {
+          output[1] = addPlaceholders(expression[1])
+          output[2] = ['\\mathinner', ['Missing', '']]
+        } else if (functionName == 'Evaluate') {
+          output[1] = addPlaceholders(expression[1])
+          output[3] = ['\\mathinner', ['Missing', '']]
         } else {
           for (let i = 1; i < expression.length; i++) {
-            output[i] = addPlaceholders(expression[i]);
+            output[i] = addPlaceholders(expression[i])
           }
         }
-        return output;
+        return output
       } else {
-        return expression;
+        return expression
       }
     }
 
-    setExpression(clearPlaceholders(expression.value));
+    setExpression(clearPlaceholders(expression.value))
   }
 
   function inputExpression(value: Expression) {
     // TODO: Make expression value readonly
-    setGetters(getGetterNames(value));
-    setVariables(getVariableNames(value));
+    setGetters(getGetterNames(value))
+    setVariables(getVariableNames(value))
 
-    assert(block.scope.value, "Expected the block to have a scope");
+    assert(block.scope.value, 'Expected the block to have a scope')
 
-    setExpression(addPlaceholders(value));
+    setExpression(addPlaceholders(value))
     // Cascading invalidation, only the topmost ones will be valid commands
-    clearVariableValues();
-    evaluateLater();
+    clearVariableValues()
+    evaluateLater()
   }
 
   watch(block.scope, (value) => {
     if (value) {
       // TODO: Re-create getters and variables when the scope changes
-      clearVariableValues();
-      clearPlaceholders();
-      evaluateLater();
+      clearVariableValues()
+      clearPlaceholders()
+      evaluateLater()
     } else {
-      setGetters(new Set<string>());
-      setVariables(new Set<string>());
+      setGetters(new Set<string>())
+      setVariables(new Set<string>())
       if (runningCasExpression.value) {
-        cas.cancelCommand(runningCasExpression.value);
+        cas.cancelCommand(runningCasExpression.value)
       }
     }
-  });
+  })
 
   function evaluateLater() {
     if (runningCasExpression.value) {
-      cas.cancelCommand(runningCasExpression.value);
+      cas.cancelCommand(runningCasExpression.value)
     }
 
     // Check if all getters that should have a value actually do have a value
-    const gettersData = new Map<string, any>();
-    let allDataDefined = true;
+    const gettersData = new Map<string, any>()
+    let allDataDefined = true
     getters.forEach((value, key) => {
-      const data = value.data.value;
+      const data = value.data.value
       if (data === undefined) {
         // It's a symbol
       } else if (data === null) {
         // Variable is missing its data
-        allDataDefined = false;
+        allDataDefined = false
       } else {
-        gettersData.set(key, data);
+        gettersData.set(key, data)
       }
-    });
+    })
 
     if (!allDataDefined || !expression.value) {
-      return;
+      return
     }
 
     // TODO:
@@ -209,77 +200,71 @@ function useExpressionElement(block: UseQuantumElement): UseExpressionElement {
       */
 
     // TODO: Fix c:=8+4=
-    function evaluateExpression(
-      expression: any,
-      callback: (result: any) => void
-    ) {
+    function evaluateExpression(expression: any, callback: (result: any) => void) {
       if (Array.isArray(expression)) {
-        const functionName = expression[0];
-        if (functionName == "Equal") {
+        const functionName = expression[0]
+        if (functionName == 'Equal') {
           evaluateExpression(expression[1], (result) => {
-            const casExpression = expression.slice();
-            casExpression[1] = result;
+            const casExpression = expression.slice()
+            casExpression[1] = result
 
             runningCasExpression.value = new CasCommand(
               gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
               casExpression,
               (result) => {
                 // TODO: Fix this for nested equals signs/expressions
-                const output = expression.slice();
-                output[2] = ["\\mathinner", result]; // A part of the expression, namely the one with the placeholder, gets replaced
-                setExpression(output);
-                callback(result);
+                const output = expression.slice()
+                output[2] = ['\\mathinner', result] // A part of the expression, namely the one with the placeholder, gets replaced
+                setExpression(output)
+                callback(result)
               }
-            );
-            cas.executeCommand(runningCasExpression.value);
-          });
-        } else if (functionName == "Evaluate") {
+            )
+            cas.executeCommand(runningCasExpression.value)
+          })
+        } else if (functionName == 'Evaluate') {
           evaluateExpression(expression[1], (result) => {
-            const casExpression = expression.slice();
-            casExpression[1] = result;
+            const casExpression = expression.slice()
+            casExpression[1] = result
 
             runningCasExpression.value = new CasCommand(
               gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
               casExpression,
               (result) => {
                 // TODO: Fix this for nested equals signs/expressions
-                const output = expression.slice();
-                output[3] = ["\\mathinner", result];
-                setExpression(output);
-                callback(result);
+                const output = expression.slice()
+                output[3] = ['\\mathinner', result]
+                setExpression(output)
+                callback(result)
               }
-            );
-            cas.executeCommand(runningCasExpression.value);
-          });
-        } else if (functionName == "Apply") {
+            )
+            cas.executeCommand(runningCasExpression.value)
+          })
+        } else if (functionName == 'Apply') {
           // TODO:
         } else {
-          callback(expression);
+          callback(expression)
         }
       } else {
-        callback(expression);
+        callback(expression)
       }
     }
 
-    if (Array.isArray(expression.value) && expression.value[0] == "Assign") {
+    if (Array.isArray(expression.value) && expression.value[0] == 'Assign') {
       evaluateExpression(expression.value[2], (result) => {
         runningCasExpression.value = new CasCommand(
           gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
-          ["Equal", result, null],
+          ['Equal', result, null],
           (result) => {
             // TODO: Support assigning to multiple variables
-            assert(
-              variables.size === 1,
-              "Assigning to multiple variables not supported yet"
-            );
-            variables.forEach((v) => v.setData(result));
+            assert(variables.size === 1, 'Assigning to multiple variables not supported yet')
+            variables.forEach((v) => v.setData(result))
           }
-        );
-        cas.executeCommand(runningCasExpression.value);
-      });
+        )
+        cas.executeCommand(runningCasExpression.value)
+      })
     } else {
-      assert(variables.size === 0, "Expected no variables");
-      evaluateExpression(expression.value, (result) => {});
+      assert(variables.size === 0, 'Expected no variables')
+      evaluateExpression(expression.value, (result) => {})
     }
   }
 
@@ -288,29 +273,26 @@ function useExpressionElement(block: UseQuantumElement): UseExpressionElement {
     getters,
     variables,
     expression,
-    inputExpression,
-  };
+    inputExpression
+  }
 }
 
 function serializeElement(element: UseExpressionElement): string {
-  throw new Error(`Serialization not implemented yet`);
+  throw new Error(`Serialization not implemented yet`)
 }
 
 function deserializeElement(data: string): UseExpressionElement {
-  throw new Error(`Serialization not implemented yet`);
+  throw new Error(`Serialization not implemented yet`)
 }
 
-export const ExpressionElementType: QuantumElementType<
-  UseExpressionElement,
-  typeof ElementType
-> = {
+export const ExpressionElementType: QuantumElementType<UseExpressionElement, typeof ElementType> = {
   typeName: ElementType,
   documentType: {
     [ElementType]: {
       typeName: ElementType,
       useElement: useExpressionElement,
       serializeElement: serializeElement,
-      deserializeElement: deserializeElement,
-    },
-  },
-};
+      deserializeElement: deserializeElement
+    }
+  }
+}

--- a/src/model/document/elements/scope-element.ts
+++ b/src/model/document/elements/scope-element.ts
@@ -137,7 +137,7 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
       position: position,
       index: 0,
       data: shallowRef(),
-      getters: []
+      getters: [],
     })
 
     const newVariableArray = reactive([importerVariable])
@@ -157,7 +157,7 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
       position: position,
       index: -1,
       data: shallowRef<any>(null),
-      getters: []
+      getters: [],
     })
 
     const variableArray =
@@ -204,7 +204,7 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
         variable.index = index
       },
       {
-        immediate: true
+        immediate: true,
       }
     )
 
@@ -218,14 +218,14 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
 
     return {
       setData,
-      remove
+      remove,
     }
   }
 
   function addGetter(name: string, position: ComputedRef<Vector2>) {
     const getter: ScopedGetter = reactive({
       position: position,
-      variable: undefined
+      variable: undefined,
     })
     const data = computed(() => getter.variable?.data)
 
@@ -245,7 +245,7 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
           if (
             isInRange(value, {
               start: getter.variable.position,
-              end: nextVariable?.position
+              end: nextVariable?.position,
             })
           ) {
             return
@@ -276,7 +276,7 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
 
     return {
       data,
-      remove
+      remove,
     }
   }
 
@@ -287,7 +287,7 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
     variableMap: variableMap,
     setName,
     addVariable,
-    addGetter
+    addGetter,
   }
 }
 
@@ -306,7 +306,7 @@ export const ScopeElementType: QuantumElementType<UseScopeElement, typeof Elemen
       typeName: ElementType,
       useElement: useScopeElement,
       serializeElement: serializeElement,
-      deserializeElement: deserializeElement
-    }
-  }
+      deserializeElement: deserializeElement,
+    },
+  },
 }

--- a/src/model/document/elements/scope-element.ts
+++ b/src/model/document/elements/scope-element.ts
@@ -1,44 +1,35 @@
-import { QuantumElementType, UseQuantumElement } from "../document-element";
-import {
-  ref,
-  Ref,
-  reactive,
-  shallowRef,
-  watch,
-  watchEffect,
-  computed,
-  ComputedRef,
-} from "vue";
-import { Vector2 } from "../../vectors";
-import arrayUtils from "../../array-utils";
-import { assert } from "../../assert";
+import { QuantumElementType, UseQuantumElement } from '../document-element'
+import { ref, Ref, reactive, shallowRef, watch, watchEffect, computed, ComputedRef } from 'vue'
+import { Vector2 } from '../../vectors'
+import arrayUtils from '../../array-utils'
+import { assert } from '../../assert'
 
-export const ElementType = "scope-element";
+export const ElementType = 'scope-element'
 
 export interface UseScopeElement extends UseQuantumElement {
   /**
    * Name of the scope, used for named imports
    */
-  name: Ref<string>;
+  name: Ref<string>
 
   /**
    * A closed scope does not auto-import variables from its parent scope
    */
-  closed: Ref<boolean>;
+  closed: Ref<boolean>
 
   /**
    * Variables defined in this scope
    * 0th variable is always the import-variable
    */
-  variableMap: ReadonlyMap<string, ScopedVariable[]>;
+  variableMap: ReadonlyMap<string, ScopedVariable[]>
 
   // Note: I'll try to not use childScopes for now. I think I can get away without them.
 
-  setName(value: string): void;
+  setName(value: string): void
 
-  addVariable(name: string, position: ComputedRef<Vector2>): UseScopedVariable;
+  addVariable(name: string, position: ComputedRef<Vector2>): UseScopedVariable
 
-  addGetter(name: string, position: ComputedRef<Vector2>): UseScopedGetter;
+  addGetter(name: string, position: ComputedRef<Vector2>): UseScopedGetter
 }
 
 // TODO: Scope end element
@@ -50,8 +41,8 @@ export interface UseScopedVariable {
    * - `null` is a variable without data
    * - anything else is data
    */
-  setData(data: any): void; // TODO: Use MathJson type
-  remove(): void;
+  setData(data: any): void // TODO: Use MathJson type
+  remove(): void
 }
 
 export interface UseScopedGetter {
@@ -60,8 +51,8 @@ export interface UseScopedGetter {
    * - `null` is a variable without data
    * - anything else is data
    */
-  data: ComputedRef<any>;
-  remove(): void;
+  data: ComputedRef<any>
+  remove(): void
 }
 
 // Internal interfaces
@@ -69,74 +60,68 @@ interface ScopedVariable {
   /**
    * Variable position
    */
-  readonly position: Vector2;
+  readonly position: Vector2
 
   /**
    * Variable index in array
    */
-  index: number;
+  index: number
 
   /**
    * Shallow ref variable data
    *
    */
-  data: any;
+  data: any
 
   /**
    * Variable getters
    */
-  getters: ScopedGetter[];
+  getters: ScopedGetter[]
 }
 
 interface ScopedGetter {
   /**
    * Getter position
    */
-  readonly position: Vector2;
+  readonly position: Vector2
 
   /**
    * Getter variable
    */
-  variable: ScopedVariable | undefined;
+  variable: ScopedVariable | undefined
 }
 
-function removeVariable(
-  variableArray: ScopedVariable[],
-  variable: ScopedVariable
-) {
-  if (variable.index < 0) return;
+function removeVariable(variableArray: ScopedVariable[], variable: ScopedVariable) {
+  if (variable.index < 0) return
 
   if (variable.getters.length > 0) {
-    const prev = arrayUtils.tryGetElement(variableArray, variable.index - 1);
-    assert(prev, "Expected prev variable to exist");
+    const prev = arrayUtils.tryGetElement(variableArray, variable.index - 1)
+    assert(prev, 'Expected prev variable to exist')
 
-    prev.getters = prev.getters.concat(variable.getters);
-    variable.getters.forEach((v) => (v.variable = prev));
-    variable.getters = [];
+    prev.getters = prev.getters.concat(variable.getters)
+    variable.getters.forEach((v) => (v.variable = prev))
+    variable.getters = []
   }
 
   // Remove variable and update indices
-  variableArray.splice(variable.index, 1);
+  variableArray.splice(variable.index, 1)
   for (let i = variable.index; i < variableArray.length; i++) {
-    variableArray[i].index = i;
+    variableArray[i].index = i
   }
-  variable.index = -1;
+  variable.index = -1
 }
 
 function isInRange(value: Vector2, range: { start?: Vector2; end?: Vector2 }) {
-  return (
-    (!range.start || range.start.compareTo(value) <= 0) &&
-    (!range.end || value.compareTo(range.end) < 0)
-  );
+  return (!range.start || range.start.compareTo(value) <= 0) && (!range.end || value.compareTo(range.end) < 0)
 }
 
 function useScopeElement(block: UseQuantumElement): UseScopeElement {
-  const name = ref("");
-  const closed = ref(false);
-  const variableMap = reactive(new Map<string, ScopedVariable[]>());
+  const name = ref('')
+  const closed = ref(false)
+  const variableMap = reactive(new Map<string, ScopedVariable[]>())
 
   function setName(value: string) {
-    name.value = value;
+    name.value = value
   }
 
   /*const imports = computed(() => {
@@ -147,29 +132,23 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
     });
   })*/
 
-  function createVariableArray(
-    name: string,
-    position: ComputedRef<Vector2>
-  ): ScopedVariable[] {
+  function createVariableArray(name: string, position: ComputedRef<Vector2>): ScopedVariable[] {
     const importerVariable: ScopedVariable = reactive({
       position: position,
       index: 0,
       data: shallowRef(),
-      getters: [],
-    });
+      getters: []
+    })
 
-    const newVariableArray = reactive([importerVariable]);
-    watch(
-      [() => newVariableArray.length, () => importerVariable.getters.length],
-      ([variableArrayLength, gettersLength]) => {
-        if (variableArrayLength <= 1 && gettersLength == 0) {
-          variableMap.delete(name);
-        }
+    const newVariableArray = reactive([importerVariable])
+    watch([() => newVariableArray.length, () => importerVariable.getters.length], ([variableArrayLength, gettersLength]) => {
+      if (variableArrayLength <= 1 && gettersLength == 0) {
+        variableMap.delete(name)
       }
-    );
+    })
 
-    variableMap.set(name, newVariableArray);
-    return newVariableArray;
+    variableMap.set(name, newVariableArray)
+    return newVariableArray
   }
 
   function addVariable(name: string, position: ComputedRef<Vector2>) {
@@ -178,152 +157,127 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
       position: position,
       index: -1,
       data: shallowRef<any>(null),
-      getters: [],
-    });
+      getters: []
+    })
 
     const variableArray =
       variableMap.get(name) ??
       createVariableArray(
         name,
         computed(() => block.position.value)
-      );
+      )
 
     watch(
       () => variable.position,
       (value) => {
         // Remove (or bail out)
         if (variable.index >= 0) {
-          assert(
-            variableArray[variable.index] == variable,
-            `Expected variable ${variable} to be in ${variableArray} at index ${variable.index}`
-          );
+          assert(variableArray[variable.index] == variable, `Expected variable ${variable} to be in ${variableArray} at index ${variable.index}`)
 
-          const prev = arrayUtils.tryGetElement(
-            variableArray,
-            variable.index - 1
-          );
-          const next = arrayUtils.tryGetElement(
-            variableArray,
-            variable.index + 1
-          );
+          const prev = arrayUtils.tryGetElement(variableArray, variable.index - 1)
+          const next = arrayUtils.tryGetElement(variableArray, variable.index + 1)
 
-          if (
-            isInRange(value, { start: prev?.position, end: next?.position })
-          ) {
-            return;
+          if (isInRange(value, { start: prev?.position, end: next?.position })) {
+            return
           }
 
-          removeVariable(variableArray, variable);
+          removeVariable(variableArray, variable)
         }
 
         // Add
-        const { index } = arrayUtils.getBinaryInsertIndex(variableArray, (v) =>
-          v.position.compareTo(value)
-        );
+        const { index } = arrayUtils.getBinaryInsertIndex(variableArray, (v) => v.position.compareTo(value))
 
-        const prev = arrayUtils.tryGetElement(variableArray, index - 1);
+        const prev = arrayUtils.tryGetElement(variableArray, index - 1)
         // Take some getters from prev
         if (prev?.getters) {
-          variable.getters = prev.getters.filter(
-            (v) => value.compareTo(v.position) <= 0
-          );
+          variable.getters = prev.getters.filter((v) => value.compareTo(v.position) <= 0)
           variable.getters.forEach((v) => {
-            v.variable = variable;
-          });
-          prev.getters = prev.getters.filter(
-            (v) => v.position.compareTo(value) < 0
-          );
+            v.variable = variable
+          })
+          prev.getters = prev.getters.filter((v) => v.position.compareTo(value) < 0)
         }
         // Update variable indices
         for (let i = index; i < variableArray.length; i++) {
-          variableArray[i].index = i + 1;
+          variableArray[i].index = i + 1
         }
-        variableArray.splice(index, 0, variable);
-        variable.index = index;
+        variableArray.splice(index, 0, variable)
+        variable.index = index
       },
       {
-        immediate: true,
+        immediate: true
       }
-    );
+    )
 
     function setData(data: any) {
-      variable.data = data;
+      variable.data = data
     }
 
     function remove() {
-      removeVariable(variableArray, variable);
+      removeVariable(variableArray, variable)
     }
 
     return {
       setData,
-      remove,
-    };
+      remove
+    }
   }
 
   function addGetter(name: string, position: ComputedRef<Vector2>) {
     const getter: ScopedGetter = reactive({
       position: position,
-      variable: undefined,
-    });
-    const data = computed(() => getter.variable?.data);
+      variable: undefined
+    })
+    const data = computed(() => getter.variable?.data)
 
     const variableArray =
       variableMap.get(name) ??
       createVariableArray(
         name,
         computed(() => block.position.value)
-      );
+      )
 
     watch(
       () => getter.position,
       (value) => {
         if (getter.variable) {
           // If the getter is still in the correct position, bail out
-          const nextVariable = arrayUtils.tryGetElement(
-            variableArray,
-            getter.variable.index + 1
-          );
+          const nextVariable = arrayUtils.tryGetElement(variableArray, getter.variable.index + 1)
           if (
             isInRange(value, {
               start: getter.variable.position,
-              end: nextVariable?.position,
+              end: nextVariable?.position
             })
           ) {
-            return;
+            return
           }
 
           // Remove getter from old variable
-          arrayUtils.remove(getter.variable.getters, getter);
-          getter.variable = undefined;
+          arrayUtils.remove(getter.variable.getters, getter)
+          getter.variable = undefined
         }
 
-        const { index } = arrayUtils.getBinaryInsertIndex(variableArray, (v) =>
-          v.position.compareTo(value)
-        );
+        const { index } = arrayUtils.getBinaryInsertIndex(variableArray, (v) => v.position.compareTo(value))
 
-        const variable = arrayUtils.tryGetElement(variableArray, index - 1);
-        assert(
-          variable,
-          `Getter position ${getter.position} outside of block ${block.position}`
-        );
+        const variable = arrayUtils.tryGetElement(variableArray, index - 1)
+        assert(variable, `Getter position ${getter.position} outside of block ${block.position}`)
 
         // Add getter to variable
-        variable.getters.push(getter);
-        getter.variable = variable;
+        variable.getters.push(getter)
+        getter.variable = variable
       },
       { immediate: true }
-    );
+    )
 
     function remove() {
-      if (!getter.variable) return;
-      arrayUtils.remove(getter.variable.getters, getter);
-      getter.variable = undefined;
+      if (!getter.variable) return
+      arrayUtils.remove(getter.variable.getters, getter)
+      getter.variable = undefined
     }
 
     return {
       data,
-      remove,
-    };
+      remove
+    }
   }
 
   return {
@@ -333,29 +287,26 @@ function useScopeElement(block: UseQuantumElement): UseScopeElement {
     variableMap: variableMap,
     setName,
     addVariable,
-    addGetter,
-  };
+    addGetter
+  }
 }
 
 function serializeElement(element: UseScopeElement): string {
-  throw new Error(`Serialization not implemented yet`);
+  throw new Error(`Serialization not implemented yet`)
 }
 
 function deserializeElement(data: string): UseScopeElement {
-  throw new Error(`Serialization not implemented yet`);
+  throw new Error(`Serialization not implemented yet`)
 }
 
-export const ScopeElementType: QuantumElementType<
-  UseScopeElement,
-  typeof ElementType
-> = {
+export const ScopeElementType: QuantumElementType<UseScopeElement, typeof ElementType> = {
   typeName: ElementType,
   documentType: {
     [ElementType]: {
       typeName: ElementType,
       useElement: useScopeElement,
       serializeElement: serializeElement,
-      deserializeElement: deserializeElement,
-    },
-  },
-};
+      deserializeElement: deserializeElement
+    }
+  }
+}

--- a/src/model/mathjson-custom-dictionary.ts
+++ b/src/model/mathjson-custom-dictionary.ts
@@ -89,7 +89,7 @@ dictionary.push({
 
     const rhs = scanner.matchExpression(260)
     return [null, ['Evaluate', lhs, solveArgument, rhs]]
-  }
+  },
 })
 
 // TODO: Add a proper text parser
@@ -99,5 +99,5 @@ dictionary.push({
   serialize: function (emitter, expr) {
     if (!Array.isArray(expr)) throw new Error('Expect array expression')
     return `\\text{${expr[1]}}`
-  }
+  },
 })

--- a/src/model/mathjson-custom-dictionary.ts
+++ b/src/model/mathjson-custom-dictionary.ts
@@ -1,12 +1,7 @@
-import { Expression, LatexSyntax } from "@cortex-js/compute-engine";
-import {
-  LatexDictionary,
-  ParserFunction,
-  Scanner,
-  SerializerFunction,
-} from "@cortex-js/compute-engine/dist/types/latex-syntax/public";
+import { Expression, LatexSyntax } from '@cortex-js/compute-engine'
+import { LatexDictionary, ParserFunction, Scanner, SerializerFunction } from '@cortex-js/compute-engine/dist/types/latex-syntax/public'
 
-const MISSING = "Missing";
+const MISSING = 'Missing'
 
 /*
 References:
@@ -31,12 +26,12 @@ https://github.com/cortex-js/compute-engine/blob/680462ea46b9d5c4c53d046d807bd9e
  * `=` being used to (numerically) evaluate something
  * `->` being used to symbolically evaluate something
  */
-export const dictionary = LatexSyntax.getDictionary() as LatexDictionary<any>; // A bit of a hack
+export const dictionary = LatexSyntax.getDictionary() as LatexDictionary<any> // A bit of a hack
 // console.log(dictionary);
 
 // `a == b =` should be parsed as `(a == b) =`
 // Basically, it should first check whether the two are equivalent and then calculate the result
-dictionary.find((v) => v.name === "EqualEqual")!.precedence = 265;
+dictionary.find((v) => v.name === 'EqualEqual')!.precedence = 265
 
 // TODO: Check out the precedences for things like LessEqual
 // TODO: Document those custom symbols, because they're non-standard mathjson. They're a part of the QuantumSheet backend
@@ -44,65 +39,65 @@ dictionary.find((v) => v.name === "EqualEqual")!.precedence = 265;
 // Evaluate should be special, as to not conflict with things like `lim_{n \to 3}`
 // `x^2 + 3x + c == 0 -> ` should evaluate the quadratic equation
 
-export const EVALUATE = "Evaluate";
+export const EVALUATE = 'Evaluate'
 
 dictionary.push({
   precedence: 260,
   name: EVALUATE,
   optionalLatexArg: 1,
   requiredLatexArg: 1,
-  trigger: { infix: "\\xrightarrow" },
+  trigger: { infix: '\\xrightarrow' },
   serialize: <SerializerFunction<number>>function (emitter, expr) {
-    console.log(expr);
-    if (!Array.isArray(expr)) throw new Error("Expect array expression");
+    console.log(expr)
+    if (!Array.isArray(expr)) throw new Error('Expect array expression')
 
     return (
       emitter.wrap(expr[1], 260) +
       `\\xrightarrow{${
         Array.isArray(expr[2]) && expr[2][0] == MISSING // TODO: Make this more elegant
-          ? "\\placeholder{}"
+          ? '\\placeholder{}'
           : expr[2]
       }}` +
       emitter.wrap(expr[3], 260)
-    );
+    )
   },
   parse: <ParserFunction<number>>function (lhs, scanner, minPrec) {
-    if (260 < minPrec) return [lhs, null];
-    if (!scanner.match("\\xrightarrow")) return [lhs, null];
+    if (260 < minPrec) return [lhs, null]
+    if (!scanner.match('\\xrightarrow')) return [lhs, null]
 
-    scanner.matchOptionalLatexArgument();
+    scanner.matchOptionalLatexArgument()
     //const solveArgument = scanner.matchRequiredLatexArgument(); // TODO: Add the solve keyword to known stuff
-    let solveArgument: string | string[] = "";
-    scanner.skipSpace();
-    if (scanner.match("<{>")) {
-      let level = 1;
+    let solveArgument: string | string[] = ''
+    scanner.skipSpace()
+    if (scanner.match('<{>')) {
+      let level = 1
       while (!scanner.atEnd && level !== 0) {
-        if (scanner.match("<{>")) {
-          level += 1;
-        } else if (scanner.match("<}>")) {
-          level -= 1;
-        } else if (scanner.match("<space>")) {
-          solveArgument += " ";
+        if (scanner.match('<{>')) {
+          level += 1
+        } else if (scanner.match('<}>')) {
+          level -= 1
+        } else if (scanner.match('<space>')) {
+          solveArgument += ' '
         } else {
-          solveArgument += scanner.next();
+          solveArgument += scanner.next()
         }
       }
     }
-    if (solveArgument.startsWith("\\placeholder")) {
-      solveArgument = [MISSING, solveArgument.replace(/^\\placeholder/, "")];
+    if (solveArgument.startsWith('\\placeholder')) {
+      solveArgument = [MISSING, solveArgument.replace(/^\\placeholder/, '')]
     }
 
-    const rhs = scanner.matchExpression(260);
-    return [null, ["Evaluate", lhs, solveArgument, rhs]];
-  },
-});
+    const rhs = scanner.matchExpression(260)
+    return [null, ['Evaluate', lhs, solveArgument, rhs]]
+  }
+})
 
 // TODO: Add a proper text parser
 dictionary.push({
-  name: "\\text",
-  parse: "\\text",
+  name: '\\text',
+  parse: '\\text',
   serialize: function (emitter, expr) {
-    if (!Array.isArray(expr)) throw new Error("Expect array expression");
-    return `\\text{${expr[1]}}`;
-  },
-});
+    if (!Array.isArray(expr)) throw new Error('Expect array expression')
+    return `\\text{${expr[1]}}`
+  }
+})

--- a/src/model/vectors.ts
+++ b/src/model/vectors.ts
@@ -2,34 +2,34 @@
  * A simple readonly Vector2
  */
 export class Vector2 {
-  readonly x: number;
-  readonly y: number;
+  readonly x: number
+  readonly y: number
   constructor(x: number, y: number) {
-    this.x = x;
-    this.y = y;
+    this.x = x
+    this.y = y
   }
 
   static get zero(): Vector2 {
-    return new Vector2(0, 0);
+    return new Vector2(0, 0)
   }
 
   get length() {
-    return Math.hypot(this.x, this.y);
+    return Math.hypot(this.x, this.y)
   }
 
   static clone(other: Vector2): Vector2 {
-    return new Vector2(other.x, other.y);
+    return new Vector2(other.x, other.y)
   }
 
   add(other: Vector2): Vector2 {
-    return new Vector2(this.x + other.x, this.y + other.y);
+    return new Vector2(this.x + other.x, this.y + other.y)
   }
 
   /**
    * For sorting in an array
    */
   compareTo(other: Vector2) {
-    if (this.y == other.y) return this.x - other.x;
-    return this.y - other.y;
+    if (this.y == other.y) return this.x - other.x
+    return this.y - other.y
   }
 }

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -5,12 +5,13 @@
     tabindex="-1"
     :style="{
       '--grid-cell-size-x': `${document.gridCellSize.x}px`,
-      '--grid-cell-size-y': `${document.gridCellSize.y}px`,
+      '--grid-cell-size-y': `${document.gridCellSize.y}px`
     }"
     @pointerdown="grid.pointerDown($event)"
     @paste="clipboard.paste"
     @focus="documentInputElement.focus()"
   >
+    <!-- prettier-ignore -->
     <textarea
       class="input-element"
       ref="documentInputElement"
@@ -27,13 +28,7 @@
       "
       @blur="grid.showCrosshair.value = false"
     ></textarea>
-    <div
-      class="grid-crosshair"
-      :style="grid.gridToStyle(grid.crosshairPosition.value)"
-      v-show="grid.showCrosshair.value"
-    >
-      +
-    </div>
+    <div class="grid-crosshair" :style="grid.gridToStyle(grid.crosshairPosition.value)" v-show="grid.showCrosshair.value">+</div>
     <div
       class="quantum-block"
       v-for="element in document.elements"
@@ -46,9 +41,7 @@
         :is="getTypeComponent(element.typeName)"
         class="quantum-element"
         :modelGetter="() => element"
-        @focused-element-commands="
-          (value) => (focusedElementCommands.commands.value = value)
-        "
+        @focused-element-commands="(value) => (focusedElementCommands.commands.value = value)"
         @move-cursor-out="(value) => grid.moveCrosshairOut(element, value)"
         @delete-element="document.deleteElement(element)"
       ></component>
@@ -56,44 +49,23 @@
   </div>
 </template>
 <script lang="ts">
-import {
-  defineComponent,
-  readonly,
-  ref,
-  Ref,
-  nextTick,
-  unref,
-  onMounted,
-} from "vue";
-import {
-  useDocument,
-  UseQuantumDocument,
-  QuantumDocumentElementTypes,
-} from "../model/document/document";
-import ExpressionElement, {
-  ExpressionElementType,
-} from "./elements/ExpressionElement.vue";
-import ScopeElement, {
-  ScopeElementType,
-} from "./elements/ScopeStartElement.vue";
-import {
-  useFocusedElementCommands,
-  ElementCommands,
-} from "./elements/element-commands";
-import { Vector2 } from "../model/vectors";
-import { UseQuantumElement } from "../model/document/document-element";
+import { defineComponent, readonly, ref, Ref, nextTick, unref, onMounted } from 'vue'
+import { useDocument, UseQuantumDocument, QuantumDocumentElementTypes } from '../model/document/document'
+import ExpressionElement, { ExpressionElementType } from './elements/ExpressionElement.vue'
+import ScopeElement, { ScopeElementType } from './elements/ScopeStartElement.vue'
+import { useFocusedElementCommands, ElementCommands } from './elements/element-commands'
+import { Vector2 } from '../model/vectors'
+import { UseQuantumElement } from '../model/document/document-element'
 
-function useClipboard<T extends QuantumDocumentElementTypes>(
-  document: UseQuantumDocument<T>
-) {
+function useClipboard<T extends QuantumDocumentElementTypes>(document: UseQuantumDocument<T>) {
   function cut(ev: ClipboardEvent) {}
   function copy(ev: ClipboardEvent) {}
   function paste(ev: ClipboardEvent) {}
   return {
     cut,
     copy,
-    paste,
-  };
+    paste
+  }
 }
 
 function useGrid<T extends QuantumDocumentElementTypes>(
@@ -101,89 +73,81 @@ function useGrid<T extends QuantumDocumentElementTypes>(
   inputElement: Ref<HTMLElement | undefined>,
   focusedElementCommands: Ref<ElementCommands | undefined>
 ) {
-  const crosshairPosition = ref<Vector2>(new Vector2(2, 10));
-  const showCrosshair = ref(true);
+  const crosshairPosition = ref<Vector2>(new Vector2(2, 10))
+  const showCrosshair = ref(true)
 
   function gridToStyle(gridPosition: Vector2 | Ref<Vector2>) {
-    let pos = unref(gridPosition);
+    let pos = unref(gridPosition)
     return {
-      left: pos.x * document.gridCellSize.x + "px",
-      top: pos.y * document.gridCellSize.y + "px",
-    };
+      left: pos.x * document.gridCellSize.x + 'px',
+      top: pos.y * document.gridCellSize.y + 'px'
+    }
   }
 
   function pointerDown(ev: PointerEvent) {
     if (ev.target == ev.currentTarget) {
-      crosshairPosition.value = new Vector2(
-        Math.round(ev.offsetX / document.gridCellSize.x),
-        Math.round(ev.offsetY / document.gridCellSize.y)
-      );
+      crosshairPosition.value = new Vector2(Math.round(ev.offsetX / document.gridCellSize.x), Math.round(ev.offsetY / document.gridCellSize.y))
     }
   }
 
   function textInput(ev: InputEvent) {
-    if (ev.isComposing) return;
+    if (ev.isComposing) return
 
     if (ev.data) {
       let element = document.createElement(ExpressionElementType.typeName, {
         position: crosshairPosition.value,
-        resizeable: false,
-      });
-      document.setFocus(element);
+        resizeable: false
+      })
+      document.setFocus(element)
       nextTick(() => {
-        focusedElementCommands.value?.moveToStart?.();
-        focusedElementCommands.value?.insert?.(ev.data + "");
-      });
+        focusedElementCommands.value?.moveToStart?.()
+        focusedElementCommands.value?.insert?.(ev.data + '')
+      })
     }
 
     if (ev.currentTarget) {
-      (ev.currentTarget as HTMLTextAreaElement).value = "";
+      ;(ev.currentTarget as HTMLTextAreaElement).value = ''
     }
   }
 
   function keydown(ev: KeyboardEvent) {
-    if (ev.isComposing) return;
+    if (ev.isComposing) return
 
-    let direction = Vector2.zero;
-    if (ev.key == "ArrowLeft") {
-      direction = new Vector2(-1, 0);
-    } else if (ev.key == "ArrowRight") {
-      direction = new Vector2(1, 0);
-    } else if (ev.key == "ArrowUp") {
-      direction = new Vector2(0, -1);
-    } else if (ev.key == "ArrowDown") {
-      direction = new Vector2(0, 1);
+    let direction = Vector2.zero
+    if (ev.key == 'ArrowLeft') {
+      direction = new Vector2(-1, 0)
+    } else if (ev.key == 'ArrowRight') {
+      direction = new Vector2(1, 0)
+    } else if (ev.key == 'ArrowUp') {
+      direction = new Vector2(0, -1)
+    } else if (ev.key == 'ArrowDown') {
+      direction = new Vector2(0, 1)
     } else {
-      return;
+      return
     }
 
-    crosshairPosition.value = crosshairPosition.value.add(direction);
-    focusUnderCrosshair();
+    crosshairPosition.value = crosshairPosition.value.add(direction)
+    focusUnderCrosshair()
   }
 
   function keyup(ev: KeyboardEvent) {
-    if (ev.isComposing) return;
+    if (ev.isComposing) return
   }
 
   function moveCrosshairOut(element: UseQuantumElement, direction: Vector2) {
-    let pos = element.position.value.add(
-      new Vector2(
-        direction.x > 0 ? element.size.value.x : 0,
-        direction.y > 0 ? element.size.value.y : 0
-      )
-    );
+    let pos = element.position.value.add(new Vector2(direction.x > 0 ? element.size.value.x : 0, direction.y > 0 ? element.size.value.y : 0))
 
-    crosshairPosition.value = pos.add(direction);
-    focusUnderCrosshair();
+    crosshairPosition.value = pos.add(direction)
+    focusUnderCrosshair()
   }
 
   function focusUnderCrosshair() {
     // Focus crosshair
-    inputElement.value?.focus();
+    inputElement.value?.focus()
 
     // Focus element under crosshair
-    let blockToFocus = document.getElementAt(crosshairPosition.value);
-    document.setFocus(blockToFocus);
+    let blockToFocus = document.getElementAt(crosshairPosition.value)
+    document.setFocus(blockToFocus)
   }
 
   return {
@@ -196,49 +160,44 @@ function useGrid<T extends QuantumDocumentElementTypes>(
     keyup,
 
     moveCrosshairOut,
-    focusUnderCrosshair,
-  };
+    focusUnderCrosshair
+  }
 }
 
 /**
  * To say with document-element type corresponds to which Vue.js component
  */
-type TypeComponents<T extends UseQuantumDocument<any>> =
-  T extends UseQuantumDocument<infer U> ? { [key in keyof U]: any } : any;
+type TypeComponents<T extends UseQuantumDocument<any>> = T extends UseQuantumDocument<infer U> ? { [key in keyof U]: any } : any
 
 export default defineComponent({
   components: {
     ExpressionElement,
-    ScopeElement,
+    ScopeElement
   },
   setup() {
     const document = useDocument({
       ...ExpressionElementType.documentType,
-      ...ScopeElementType.documentType,
-    });
+      ...ScopeElementType.documentType
+    })
 
     const typeComponents: TypeComponents<typeof document> = {
       [ExpressionElementType.typeName]: ExpressionElement,
-      [ScopeElementType.typeName]: ScopeElement,
-    };
+      [ScopeElementType.typeName]: ScopeElement
+    }
 
-    const documentElement = ref<HTMLElement>();
-    const documentInputElement = ref<HTMLElement>();
+    const documentElement = ref<HTMLElement>()
+    const documentInputElement = ref<HTMLElement>()
 
-    const focusedElementCommands = useFocusedElementCommands();
-    const grid = useGrid(
-      document,
-      documentInputElement,
-      focusedElementCommands.commands
-    );
-    const clipboard = useClipboard(document);
+    const focusedElementCommands = useFocusedElementCommands()
+    const grid = useGrid(document, documentInputElement, focusedElementCommands.commands)
+    const clipboard = useClipboard(document)
 
     function log(ev: any) {
-      console.log(ev);
+      console.log(ev)
     }
 
     function getTypeComponent(typeName: string) {
-      return (typeComponents as any)[typeName];
+      return (typeComponents as any)[typeName]
     }
 
     return {
@@ -250,10 +209,10 @@ export default defineComponent({
       grid,
       clipboard,
       getTypeComponent,
-      log,
-    };
-  },
-});
+      log
+    }
+  }
+})
 </script>
 
 <style scoped>
@@ -263,11 +222,7 @@ export default defineComponent({
   --selected-background-color: rgba(68, 148, 202, 0.24);
   --selected-color: rgba(57, 131, 180, 0.459);
   background-size: var(--grid-cell-size-x) var(--grid-cell-size-y);
-  background-image: linear-gradient(
-      to right,
-      var(--grid-color) 1px,
-      transparent 1px
-    ),
+  background-image: linear-gradient(to right, var(--grid-color) 1px, transparent 1px),
     linear-gradient(to bottom, var(--grid-color) 1px, transparent 1px);
   position: relative;
   touch-action: none;

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -5,7 +5,7 @@
     tabindex="-1"
     :style="{
       '--grid-cell-size-x': `${document.gridCellSize.x}px`,
-      '--grid-cell-size-y': `${document.gridCellSize.y}px`
+      '--grid-cell-size-y': `${document.gridCellSize.y}px`,
     }"
     @pointerdown="grid.pointerDown($event)"
     @paste="clipboard.paste"
@@ -64,7 +64,7 @@ function useClipboard<T extends QuantumDocumentElementTypes>(document: UseQuantu
   return {
     cut,
     copy,
-    paste
+    paste,
   }
 }
 
@@ -80,7 +80,7 @@ function useGrid<T extends QuantumDocumentElementTypes>(
     let pos = unref(gridPosition)
     return {
       left: pos.x * document.gridCellSize.x + 'px',
-      top: pos.y * document.gridCellSize.y + 'px'
+      top: pos.y * document.gridCellSize.y + 'px',
     }
   }
 
@@ -96,7 +96,7 @@ function useGrid<T extends QuantumDocumentElementTypes>(
     if (ev.data) {
       let element = document.createElement(ExpressionElementType.typeName, {
         position: crosshairPosition.value,
-        resizeable: false
+        resizeable: false,
       })
       document.setFocus(element)
       nextTick(() => {
@@ -160,7 +160,7 @@ function useGrid<T extends QuantumDocumentElementTypes>(
     keyup,
 
     moveCrosshairOut,
-    focusUnderCrosshair
+    focusUnderCrosshair,
   }
 }
 
@@ -172,17 +172,17 @@ type TypeComponents<T extends UseQuantumDocument<any>> = T extends UseQuantumDoc
 export default defineComponent({
   components: {
     ExpressionElement,
-    ScopeElement
+    ScopeElement,
   },
   setup() {
     const document = useDocument({
       ...ExpressionElementType.documentType,
-      ...ScopeElementType.documentType
+      ...ScopeElementType.documentType,
     })
 
     const typeComponents: TypeComponents<typeof document> = {
       [ExpressionElementType.typeName]: ExpressionElement,
-      [ScopeElementType.typeName]: ScopeElement
+      [ScopeElementType.typeName]: ScopeElement,
     }
 
     const documentElement = ref<HTMLElement>()
@@ -209,9 +209,9 @@ export default defineComponent({
       grid,
       clipboard,
       getTypeComponent,
-      log
+      log,
     }
-  }
+  },
 })
 </script>
 

--- a/src/ui/elements/ExpressionElement.vue
+++ b/src/ui/elements/ExpressionElement.vue
@@ -4,37 +4,33 @@
   <!--Though, you gotta figure out the whole listeners and attributes stuff-->
 </template>
 <script lang="ts">
-import { defineComponent, PropType, ref, watch, shallowRef } from "vue";
-import {
-  UseExpressionElement,
-  ExpressionElementType,
-  ElementType,
-} from "../../model/document/elements/expression-element";
-import "mathlive/dist/mathlive-fonts.css";
-import MathLive, { MathfieldElement } from "mathlive";
-import { ElementCommands } from "./element-commands";
-import { Vector2 } from "../../model/vectors";
-import { parse, serialize } from "@cortex-js/compute-engine";
-import { dictionary } from "../../model/mathjson-custom-dictionary";
+import { defineComponent, PropType, ref, watch, shallowRef } from 'vue'
+import { UseExpressionElement, ExpressionElementType, ElementType } from '../../model/document/elements/expression-element'
+import 'mathlive/dist/mathlive-fonts.css'
+import MathLive, { MathfieldElement } from 'mathlive'
+import { ElementCommands } from './element-commands'
+import { Vector2 } from '../../model/vectors'
+import { parse, serialize } from '@cortex-js/compute-engine'
+import { dictionary } from '../../model/mathjson-custom-dictionary'
 
-export { ExpressionElementType };
+export { ExpressionElementType }
 
 function setMathfieldOptions(mathfield: MathfieldElement) {
-  const keybindings = mathfield.getOption("keybindings").concat([
+  const keybindings = mathfield.getOption('keybindings').concat([
     {
-      key: "ctrl+[Period]",
-      ifMode: "math",
-      command: ["insert", "\\xrightarrow{\\placeholder{}}"],
-    },
-  ]);
+      key: 'ctrl+[Period]',
+      ifMode: 'math',
+      command: ['insert', '\\xrightarrow{\\placeholder{}}']
+    }
+  ])
 
-  const shortcuts = mathfield.getOption("inlineShortcuts");
-  shortcuts["->"] = "\\xrightarrow{\\placeholder{}}";
+  const shortcuts = mathfield.getOption('inlineShortcuts')
+  shortcuts['->'] = '\\xrightarrow{\\placeholder{}}'
 
   mathfield.setOptions({
     inlineShortcuts: shortcuts,
-    keybindings: keybindings,
-  });
+    keybindings: keybindings
+  })
 }
 
 export default defineComponent({
@@ -44,55 +40,47 @@ export default defineComponent({
      */
     modelGetter: {
       type: Function as PropType<() => UseExpressionElement>,
-      required: true,
-    },
+      required: true
+    }
   },
   emits: {
-    "focused-element-commands": (value: ElementCommands | undefined) => true,
-    "move-cursor-out": (direction: Vector2) => true, // TODO: Mathlive supports getting the screen position of the cursor. Use that!
-    "delete-element": () => true,
+    'focused-element-commands': (value: ElementCommands | undefined) => true,
+    'move-cursor-out': (direction: Vector2) => true, // TODO: Mathlive supports getting the screen position of the cursor. Use that!
+    'delete-element': () => true
   },
   setup(props, context) {
-    const mathfieldContainer = ref<HTMLElement>();
-    const mathfield = shallowRef<MathfieldElement>();
-    const expressionElement = props.modelGetter();
+    const mathfieldContainer = ref<HTMLElement>()
+    const mathfield = shallowRef<MathfieldElement>()
+    const expressionElement = props.modelGetter()
 
     // Change mathfield focus
-    watch(expressionElement.focused, (value) =>
-      value ? mathfield.value?.focus?.() : mathfield.value?.blur?.()
-    );
+    watch(expressionElement.focused, (value) => (value ? mathfield.value?.focus?.() : mathfield.value?.blur?.()))
 
     // Show expression when the document-expression changes
     watch([expressionElement.expression, mathfield], ([value, _]) => {
       const latex = serialize(value, {
-        multiply: "\\cdot",
-        invisibleMultiply: "\\cdot",
-        invisiblePlus: "+",
-        dictionary: dictionary,
+        multiply: '\\cdot',
+        invisibleMultiply: '\\cdot',
+        invisiblePlus: '+',
+        dictionary: dictionary
         // groupSeparator
-      });
+      })
 
       mathfield.value?.setValue(latex, {
-        suppressChangeNotifications: true,
-      });
-    });
+        suppressChangeNotifications: true
+      })
+    })
 
     /**
      * Evaluate the expression that the user has typed
      */
     function evaluateExpression() {
-      const expression = parse(mathfield.value?.getValue?.("latex") ?? "", {
+      const expression = parse(mathfield.value?.getValue?.('latex') ?? '', {
         dictionary: dictionary,
-        promoteUnknownFunctions: /$^/,
-      });
+        promoteUnknownFunctions: /$^/
+      })
 
-      console.log(
-        "Evaluating ",
-        mathfield.value?.getValue?.("latex"),
-        "(Mathjson form: ",
-        expression,
-        ")"
-      );
+      console.log('Evaluating ', mathfield.value?.getValue?.('latex'), '(Mathjson form: ', expression, ')')
       // TODO: Verify that the expression has no issues
       // TODO: Regarding multi letter variables
       // - Add all known variables point to dictionary
@@ -100,17 +88,17 @@ export default defineComponent({
       // TODO: What about multi letter functions?
       // TODO: Add user-defined stuff to dictionary
 
-      expressionElement.inputExpression(expression);
+      expressionElement.inputExpression(expression)
     }
 
     // Create the mathfield
     watch(
       mathfieldContainer,
       (value) => {
-        if (!value) return;
+        if (!value) return
 
         mathfield.value = new MathfieldElement({
-          defaultMode: "math",
+          defaultMode: 'math',
           // smartSuperscript: true,
           removeExtraneousParentheses: true,
           smartFence: true,
@@ -120,29 +108,28 @@ export default defineComponent({
             // TODO: If the expression is simple enough, we can optionally show a preview of the result
           },
           onFocus: (mathfield: MathLive.Mathfield) => {
-            expressionElement.setFocused(true);
-            context.emit("focused-element-commands", {
+            expressionElement.setFocused(true)
+            context.emit('focused-element-commands', {
               elementType: ElementType,
-              moveToStart: () =>
-                mathfield.executeCommand("moveToMathFieldStart"),
-              moveToEnd: () => mathfield.executeCommand("moveToMathFieldEnd"),
+              moveToStart: () => mathfield.executeCommand('moveToMathFieldStart'),
+              moveToEnd: () => mathfield.executeCommand('moveToMathFieldEnd'),
               insert: (text: string) => {
-                if (text.startsWith("\\")) {
-                  mathfield.insert(text, { mode: "latex" });
+                if (text.startsWith('\\')) {
+                  mathfield.insert(text, { mode: 'latex' })
                 } else {
-                  mathfield.insert(text);
+                  mathfield.insert(text)
                 }
-              },
-            });
+              }
+            })
           },
           onBlur: (mathfield: MathLive.Mathfield) => {
-            context.emit("focused-element-commands", undefined);
-            expressionElement.setFocused(false);
+            context.emit('focused-element-commands', undefined)
+            expressionElement.setFocused(false)
 
-            if (mathfield.getValue("latex").length == 0) {
-              context.emit("delete-element");
+            if (mathfield.getValue('latex').length == 0) {
+              context.emit('delete-element')
             } else {
-              evaluateExpression();
+              evaluateExpression()
             }
           },
           onMoveOutOf: (mathfield: MathLive.Mathfield, direction) => {
@@ -151,58 +138,54 @@ export default defineComponent({
                 forward: new Vector2(1, 0),
                 backward: new Vector2(-1, 0),
                 upward: new Vector2(0, -1),
-                downward: new Vector2(0, 1),
-              }[direction] ?? Vector2.zero;
+                downward: new Vector2(0, 1)
+              }[direction] ?? Vector2.zero
 
-            context.emit("move-cursor-out", directionVector);
-            return false;
+            context.emit('move-cursor-out', directionVector)
+            return false
           },
           onTabOutOf: (mathfield: MathLive.Mathfield, direction) => {
-            context.emit(
-              "move-cursor-out",
-              new Vector2(direction == "forward" ? 1 : -1, 0)
-            );
-            return true;
+            context.emit('move-cursor-out', new Vector2(direction == 'forward' ? 1 : -1, 0))
+            return true
           },
           onCommit: (mathfield) => {
-            mathfield.blur?.();
-            context.emit("move-cursor-out", new Vector2(0, 1));
-          },
-        });
+            mathfield.blur?.()
+            context.emit('move-cursor-out', new Vector2(0, 1))
+          }
+        })
 
-        setMathfieldOptions(mathfield.value);
+        setMathfieldOptions(mathfield.value)
 
-        mathfield.value.style.fontSize = "18px";
+        mathfield.value.style.fontSize = '18px'
 
         // TODO: Remove this hack once this gets fixed https://github.com/arnog/mathlive/issues/1056
         {
-          const caretCustomStyle = document.createElement("style");
+          const caretCustomStyle = document.createElement('style')
           caretCustomStyle.innerHTML = `.ML__caret:after {
           border-right-width: 0px !important;
           margin-right: 0px !important;
           width: 0px !important;
           box-shadow: 0px 0px 0px 1px var(--caret,hsl(var(--hue,212),40%,49%));
-         }`;
-          mathfield.value.shadowRoot?.appendChild?.(caretCustomStyle);
+         }`
+          mathfield.value.shadowRoot?.appendChild?.(caretCustomStyle)
         }
 
-        value.innerHTML = "";
-        value.appendChild(mathfield.value);
+        value.innerHTML = ''
+        value.appendChild(mathfield.value)
 
         if (expressionElement.focused.value) {
-          mathfield.value.focus();
+          mathfield.value.focus()
         }
       },
       {
-        flush: "post",
+        flush: 'post'
       }
-    );
+    )
 
     return {
-      mathfieldContainer,
-    };
-  },
-});
+      mathfieldContainer
+    }
+  }
+})
 </script>
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/ui/elements/ExpressionElement.vue
+++ b/src/ui/elements/ExpressionElement.vue
@@ -20,8 +20,8 @@ function setMathfieldOptions(mathfield: MathfieldElement) {
     {
       key: 'ctrl+[Period]',
       ifMode: 'math',
-      command: ['insert', '\\xrightarrow{\\placeholder{}}']
-    }
+      command: ['insert', '\\xrightarrow{\\placeholder{}}'],
+    },
   ])
 
   const shortcuts = mathfield.getOption('inlineShortcuts')
@@ -29,7 +29,7 @@ function setMathfieldOptions(mathfield: MathfieldElement) {
 
   mathfield.setOptions({
     inlineShortcuts: shortcuts,
-    keybindings: keybindings
+    keybindings: keybindings,
   })
 }
 
@@ -40,13 +40,13 @@ export default defineComponent({
      */
     modelGetter: {
       type: Function as PropType<() => UseExpressionElement>,
-      required: true
-    }
+      required: true,
+    },
   },
   emits: {
     'focused-element-commands': (value: ElementCommands | undefined) => true,
     'move-cursor-out': (direction: Vector2) => true, // TODO: Mathlive supports getting the screen position of the cursor. Use that!
-    'delete-element': () => true
+    'delete-element': () => true,
   },
   setup(props, context) {
     const mathfieldContainer = ref<HTMLElement>()
@@ -62,12 +62,12 @@ export default defineComponent({
         multiply: '\\cdot',
         invisibleMultiply: '\\cdot',
         invisiblePlus: '+',
-        dictionary: dictionary
+        dictionary: dictionary,
         // groupSeparator
       })
 
       mathfield.value?.setValue(latex, {
-        suppressChangeNotifications: true
+        suppressChangeNotifications: true,
       })
     })
 
@@ -77,7 +77,7 @@ export default defineComponent({
     function evaluateExpression() {
       const expression = parse(mathfield.value?.getValue?.('latex') ?? '', {
         dictionary: dictionary,
-        promoteUnknownFunctions: /$^/
+        promoteUnknownFunctions: /$^/,
       })
 
       console.log('Evaluating ', mathfield.value?.getValue?.('latex'), '(Mathjson form: ', expression, ')')
@@ -119,7 +119,7 @@ export default defineComponent({
                 } else {
                   mathfield.insert(text)
                 }
-              }
+              },
             })
           },
           onBlur: (mathfield: MathLive.Mathfield) => {
@@ -138,7 +138,7 @@ export default defineComponent({
                 forward: new Vector2(1, 0),
                 backward: new Vector2(-1, 0),
                 upward: new Vector2(0, -1),
-                downward: new Vector2(0, 1)
+                downward: new Vector2(0, 1),
               }[direction] ?? Vector2.zero
 
             context.emit('move-cursor-out', directionVector)
@@ -151,7 +151,7 @@ export default defineComponent({
           onCommit: (mathfield) => {
             mathfield.blur?.()
             context.emit('move-cursor-out', new Vector2(0, 1))
-          }
+          },
         })
 
         setMathfieldOptions(mathfield.value)
@@ -178,14 +178,14 @@ export default defineComponent({
         }
       },
       {
-        flush: 'post'
+        flush: 'post',
       }
     )
 
     return {
-      mathfieldContainer
+      mathfieldContainer,
     }
-  }
+  },
 })
 </script>
 <style scoped></style>

--- a/src/ui/elements/ScopeStartElement.vue
+++ b/src/ui/elements/ScopeStartElement.vue
@@ -13,19 +13,19 @@ export default defineComponent({
   props: {
     modelGetter: {
       type: Function as PropType<() => UseScopeElement>,
-      required: true
-    }
+      required: true,
+    },
   },
   emits: {
-    'focused-element-commands': (value: ElementCommands | undefined) => true
+    'focused-element-commands': (value: ElementCommands | undefined) => true,
   },
   setup(props, context) {
     const scopeElement = props.modelGetter()
 
     return {
-      element: scopeElement
+      element: scopeElement,
     }
-  }
+  },
 })
 </script>
 <style scoped></style>

--- a/src/ui/elements/ScopeStartElement.vue
+++ b/src/ui/elements/ScopeStartElement.vue
@@ -2,34 +2,30 @@
   <div class="scope-start"></div>
 </template>
 <script lang="ts">
-import { defineComponent, PropType, ref, watch, shallowRef } from "vue";
-import {
-  UseScopeElement,
-  ScopeElementType,
-} from "../../model/document/elements/scope-element";
-import { ElementCommands } from "./element-commands";
-import { Vector2 } from "../../model/vectors";
+import { defineComponent, PropType, ref, watch, shallowRef } from 'vue'
+import { UseScopeElement, ScopeElementType } from '../../model/document/elements/scope-element'
+import { ElementCommands } from './element-commands'
+import { Vector2 } from '../../model/vectors'
 
-export { ScopeElementType };
+export { ScopeElementType }
 
 export default defineComponent({
   props: {
     modelGetter: {
       type: Function as PropType<() => UseScopeElement>,
-      required: true,
-    },
+      required: true
+    }
   },
   emits: {
-    "focused-element-commands": (value: ElementCommands | undefined) => true,
+    'focused-element-commands': (value: ElementCommands | undefined) => true
   },
   setup(props, context) {
-    const scopeElement = props.modelGetter();
+    const scopeElement = props.modelGetter()
 
     return {
-      element: scopeElement,
-    };
-  },
-});
+      element: scopeElement
+    }
+  }
+})
 </script>
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/ui/elements/element-commands.ts
+++ b/src/ui/elements/element-commands.ts
@@ -1,20 +1,20 @@
-import { ref } from "vue";
+import { ref } from 'vue'
 
 /**
  * Every element (or cell) should support a few features for QuantumSheet to work nicely.
  * For example, `moveToStart` can be called when the user navigates into the element using the arrow keys
  */
 export interface ElementCommands {
-  elementType: string;
-  moveToStart?: () => void;
-  moveToEnd?: () => void;
-  insert?: (text: string) => void;
+  elementType: string
+  moveToStart?: () => void
+  moveToEnd?: () => void
+  insert?: (text: string) => void
 }
 
 export function useFocusedElementCommands() {
-  const commands = ref<ElementCommands>();
+  const commands = ref<ElementCommands>()
 
   return {
-    commands,
-  };
+    commands
+  }
 }

--- a/utils/download-pyodide.js
+++ b/utils/download-pyodide.js
@@ -21,7 +21,7 @@ const filesWhitelist = [
   'mpmath.js',
   'mpmath.data',
   'numpy.js',
-  'numpy.data'
+  'numpy.data',
 ]
 // Maybe:
 // micropip
@@ -40,7 +40,7 @@ const filesWhitelist = [
   console.log(`Downloading: ${latestReleaseAsset.url}`)
 
   const downloadResponse = await fetch(latestReleaseAsset.url, {
-    headers: { Accept: 'application/octet-stream' }
+    headers: { Accept: 'application/octet-stream' },
   })
   if (!downloadResponse.ok) {
     throw new Error(`unexpected download response ${latestReleaseResponse.statusText}\nHeaders:\n${latestReleaseResponse.headers}`)
@@ -55,7 +55,7 @@ const filesWhitelist = [
   const archive = createArchiveByFileExtension(outputArchivePath)
   const pyodideData = {
     version: latestRelease.tag_name,
-    identifier: latestRelease.node_id
+    identifier: latestRelease.node_id,
   }
   await archive.read(async (entry) => {
     const entryPath = entry.path.replace(/^pyodide\//, '')

--- a/utils/download-pyodide.js
+++ b/utils/download-pyodide.js
@@ -1,28 +1,28 @@
-import { createArchiveByFileExtension } from "@shockpkg/archive-files";
-import fse from "fs-extra";
-import path from "path";
-import fetch from "node-fetch";
-import util from "util";
-import { pipeline } from "stream";
+import { createArchiveByFileExtension } from '@shockpkg/archive-files'
+import fse from 'fs-extra'
+import path from 'path'
+import fetch from 'node-fetch'
+import util from 'util'
+import { pipeline } from 'stream'
 
-const streamPipeline = util.promisify(pipeline);
-const outputDirectory = path.join(path.resolve(), "public/pyodide");
+const streamPipeline = util.promisify(pipeline)
+const outputDirectory = path.join(path.resolve(), 'public/pyodide')
 const filesWhitelist = [
-  "pyodide.js",
-  "pyodide.asm.wasm",
-  "pyodide.asm.data.js",
-  "pyodide.asm.data",
-  "pyodide.asm.js",
-  "pyodide-interrupts.js",
-  "pyodide-interrupts.data",
-  "packages.json",
-  "sympy.js",
-  "sympy.data",
-  "mpmath.js",
-  "mpmath.data",
-  "numpy.js",
-  "numpy.data",
-];
+  'pyodide.js',
+  'pyodide.asm.wasm',
+  'pyodide.asm.data.js',
+  'pyodide.asm.data',
+  'pyodide.asm.js',
+  'pyodide-interrupts.js',
+  'pyodide-interrupts.data',
+  'packages.json',
+  'sympy.js',
+  'sympy.data',
+  'mpmath.js',
+  'mpmath.data',
+  'numpy.js',
+  'numpy.data'
+]
 // Maybe:
 // micropip
 // scipy
@@ -30,55 +30,40 @@ const filesWhitelist = [
 // Request:
 // gmpy
 
-(async () => {
-  const latestReleaseResponse = await fetch(
-    "https://api.github.com/repos/iodide-project/pyodide/releases/latest"
-  );
+;(async () => {
+  const latestReleaseResponse = await fetch('https://api.github.com/repos/iodide-project/pyodide/releases/latest')
   if (!latestReleaseResponse.ok) {
-    throw new Error(
-      `unexpected release api response ${latestReleaseResponse.statusText}\nHeaders:\n${latestReleaseResponse.headers}`
-    );
+    throw new Error(`unexpected release api response ${latestReleaseResponse.statusText}\nHeaders:\n${latestReleaseResponse.headers}`)
   }
-  const latestRelease = await latestReleaseResponse.json();
-  const latestReleaseAsset = latestRelease.assets.find((asset) =>
-    asset.name.startsWith("pyodide-build")
-  );
-  console.log(`Downloading: ${latestReleaseAsset.url}`);
+  const latestRelease = await latestReleaseResponse.json()
+  const latestReleaseAsset = latestRelease.assets.find((asset) => asset.name.startsWith('pyodide-build'))
+  console.log(`Downloading: ${latestReleaseAsset.url}`)
 
   const downloadResponse = await fetch(latestReleaseAsset.url, {
-    headers: { Accept: "application/octet-stream" },
-  });
+    headers: { Accept: 'application/octet-stream' }
+  })
   if (!downloadResponse.ok) {
-    throw new Error(
-      `unexpected download response ${latestReleaseResponse.statusText}\nHeaders:\n${latestReleaseResponse.headers}`
-    );
+    throw new Error(`unexpected download response ${latestReleaseResponse.statusText}\nHeaders:\n${latestReleaseResponse.headers}`)
   }
-  await fse.remove(outputDirectory);
-  await fse.ensureDir(outputDirectory);
-  const outputArchivePath = path.join(outputDirectory, latestReleaseAsset.name);
-  await streamPipeline(
-    downloadResponse.body,
-    fse.createWriteStream(outputArchivePath)
-  );
+  await fse.remove(outputDirectory)
+  await fse.ensureDir(outputDirectory)
+  const outputArchivePath = path.join(outputDirectory, latestReleaseAsset.name)
+  await streamPipeline(downloadResponse.body, fse.createWriteStream(outputArchivePath))
 
-  console.log(`Extracting ${outputArchivePath}`);
+  console.log(`Extracting ${outputArchivePath}`)
 
-  const archive = createArchiveByFileExtension(outputArchivePath);
+  const archive = createArchiveByFileExtension(outputArchivePath)
   const pyodideData = {
     version: latestRelease.tag_name,
-    identifier: latestRelease.node_id,
-  };
+    identifier: latestRelease.node_id
+  }
   await archive.read(async (entry) => {
-    const entryPath = entry.path.replace(/^pyodide\//, "");
+    const entryPath = entry.path.replace(/^pyodide\//, '')
     if (filesWhitelist.includes(entryPath)) {
-      await entry.extract(path.join(outputDirectory, entryPath));
+      await entry.extract(path.join(outputDirectory, entryPath))
     }
-  });
-  await fse.remove(outputArchivePath);
-  await fse.writeFile(
-    path.join(outputDirectory, "pyodide-data.json"),
-    JSON.stringify(pyodideData),
-    "utf8"
-  );
-  console.log("Done");
-})();
+  })
+  await fse.remove(outputArchivePath)
+  await fse.writeFile(path.join(outputDirectory, 'pyodide-data.json'), JSON.stringify(pyodideData), 'utf8')
+  console.log('Done')
+})()

--- a/utils/publish.js
+++ b/utils/publish.js
@@ -1,6 +1,6 @@
-import ghpages from "gh-pages";
+import ghpages from 'gh-pages'
 
-ghpages.publish("dist", { history: false, dotfiles: true }, (err) => {
-  if (err) console.error(err);
-  else console.log("Published to GitHub");
-});
+ghpages.publish('dist', { history: false, dotfiles: true }, (err) => {
+  if (err) console.error(err)
+  else console.log('Published to GitHub')
+})


### PR DESCRIPTION
```
{
  "trailingComma": "none",
  "tabWidth": 2,
  "semi": false,
  "singleQuote": true,
  "printWidth": 150,
  "brace_style": "collapse,preserve-inline"
}
```

- Remove unnecessary semicolons
- Line width of 150, a little larger than usual but I think it works better (I have 4:3 screen with no issue)
- Format on save
- Defaults to Prettier formatter for vscode.

Feel free to offer suggestions! I'm no picky, just as long as it is consistent within the codebase allowing for smoother PRs and such.

