### PR TITLE
Expression improvements

### DIFF
--- a/src/cas/cas-math.ts
+++ b/src/cas/cas-math.ts
@@ -64,23 +64,6 @@ export function getAllGetterNames(expression: Expression, gettersData: Map<strin
   return getterNames
 }
 
-/**
- * Variables that are being *written* to
- */
-export function getVariableNames(expression: Expression) {
-  // TODO: This can easily be done with the match function
-  const variables = new Set<string>()
-  if (Array.isArray(expression) && expression[0] == 'Assign') {
-    if (typeof expression[1] == 'string') {
-      variables.add(expression[1])
-    } else {
-      // TODO: Handle variable arrays
-      throw new Error('Cannot assign to this ' + expression[1])
-    }
-  }
-  return variables
-}
-
 export function useEncoder() {
   const textEncoder = new TextEncoder()
   const textDecoder = new TextDecoder()

--- a/src/cas/cas-math.ts
+++ b/src/cas/cas-math.ts
@@ -41,6 +41,7 @@ export function getGetterNames(expression: Expression) {
 }
 
 /**
+ * TODO: Actually this does too much. Instead, we want to get all direct getters and then any symbols that the getter might be using
  * Gets all the variables that are being read, including their references, recursively
  */
 export function getAllGetterNames(expression: Expression, gettersData: Map<string, Expression>) {

--- a/src/cas/cas-math.ts
+++ b/src/cas/cas-math.ts
@@ -32,7 +32,7 @@ export function getGetterNames(expression: Expression) {
         // Symbolical evaluation
         extractGetters(v.args[0])
       } else {
-        extractGetters(v.args)
+        extractGetters([v.head, ...v.args])
       }
     },
   })

--- a/src/cas/cas.ts
+++ b/src/cas/cas.ts
@@ -10,16 +10,33 @@ export interface UseCas {
 
 // TODO: Top level commands
 // "Assign", "Evaluate", "Equals"
-// type CasExpression = ["Assign"|"Evaluate"|"Equal"|"Apply", ...Expression[]]
+/**
+ *
+ * Assign: Assign the result to a variable or to multiple variables
+ *
+ * Equal: Numerical evaluation
+ *
+ * Evaluate: Symbolical evaluation
+ *
+ * TODO: Apply: | apply *3 | apply +2 and things like that
+ */
+export type CasExpression = ['Assign' | 'Equal' | 'Evaluate', ...Expression[]]
 
+/**
+ * A command has one expression. It is expected that all expressions/commands are submitted and executed in order.
+ *
+ * The expression can have some direct getters (e.g. 3x+5+1 has `x` as a getter)
+ * Those getters can have a value with some *undefined* symbols. For example `x = 3`, `x = 7cm` and `x = undefined` are all valid values.
+ * Notably, a getter with another getter is not okay. We do not recursively evaluate getters, instead it's expected that it has already been evaluated.
+ */
 export class CasCommand {
   readonly id: string
   readonly gettersData: Map<string, any>
-  readonly expression: Expression
+  readonly expression: CasExpression
 
   readonly callback: (result: any) => void
 
-  constructor(gettersData: Map<string, any>, expression: Expression, callback: (result: any) => void) {
+  constructor(gettersData: Map<string, any>, expression: CasExpression, callback: (result: any) => void) {
     this.id = uuidv4()
     this.gettersData = gettersData
     this.expression = expression

--- a/src/cas/cas.ts
+++ b/src/cas/cas.ts
@@ -23,6 +23,7 @@ export type CasExpression = ['Equal' | 'Evaluate', ...Expression[]]
 
 /**
  * A command has one expression. It is expected that all expressions/commands are submitted and executed in order.
+ * We'll only parse the topmost "Equal"/"Evaluate". If an expression has multiple instances of those, the user is expected to create multiple CAS commands.
  *
  * The expression can have some direct getters (e.g. 3x+5+1 has `x` as a getter)
  * Those getters can have a value with some *undefined* symbols. For example `x = 3`, `x = 7cm` and `x = undefined` are all valid values.

--- a/src/cas/cas.ts
+++ b/src/cas/cas.ts
@@ -9,10 +9,9 @@ export interface UseCas {
 }
 
 // TODO: Top level commands
-// "Assign", "Evaluate", "Equals"
+// "Evaluate", "Equals", "Apply"
 /**
  *
- * Assign: Assign the result to a variable or to multiple variables
  *
  * Equal: Numerical evaluation
  *
@@ -20,7 +19,7 @@ export interface UseCas {
  *
  * TODO: Apply: | apply *3 | apply +2 and things like that
  */
-export type CasExpression = ['Assign' | 'Equal' | 'Evaluate', ...Expression[]]
+export type CasExpression = ['Equal' | 'Evaluate', ...Expression[]]
 
 /**
  * A command has one expression. It is expected that all expressions/commands are submitted and executed in order.

--- a/src/cas/cas.ts
+++ b/src/cas/cas.ts
@@ -8,6 +8,10 @@ export interface UseCas {
   cancelCommand(command: CasCommand): void
 }
 
+// TODO: Top level commands
+// "Assign", "Evaluate", "Equals"
+// type CasExpression = ["Assign"|"Evaluate"|"Equal"|"Apply", ...Expression[]]
+
 export class CasCommand {
   readonly id: string
   readonly gettersData: Map<string, any>

--- a/src/cas/pyodide-cas.ts
+++ b/src/cas/pyodide-cas.ts
@@ -1,6 +1,6 @@
 import type {} from 'vite'
 import type { CasCommand } from './cas'
-import { getAllGetterNames, getGetterNames, useEncoder } from './cas-math'
+import { getAllGetterNames, useEncoder } from './cas-math'
 import { Expression, format } from '@cortex-js/compute-engine'
 
 export type WorkerMessage =

--- a/src/cas/pyodide-cas.ts
+++ b/src/cas/pyodide-cas.ts
@@ -2,7 +2,6 @@ import type {} from 'vite'
 import type { CasCommand } from './cas'
 import { getAllGetterNames, useEncoder } from './cas-math'
 import { Expression, format } from '@cortex-js/compute-engine'
-import * as UI from '../ui/notification'
 
 export type WorkerMessage =
   | {
@@ -336,17 +335,16 @@ export function usePyodide() {
 
         worker.onmessage = (e) => {
           let response = e.data as WorkerResponse
-          console.log('Response', response)
 
           if (response.type == 'result') {
+            console.log('Response', response)
             const command = commands.get(response.id)
             command?.callback(decodeNames(JSON.parse(response.data)))
             commands.delete(response.id)
           } else if (response.type == 'error') {
             console.warn(response)
-            UI.error('CAS error', response.message) // TODO: Make CAS independent of UI
             const command = commands.get(response.id)
-            command?.callback(['Error', 'Missing', { str: (response.message + '').slice(0, 40) }]) // Put 'error' to right of equal sign
+            command?.callback(new Error(response.message))
             commands.delete(response.id)
           } else {
             console.error('Unknown response type', response)
@@ -394,8 +392,6 @@ export function usePyodide() {
     const innerExpression = command.expression[1]
 
     let pythonExpression = ''
-    // For now, only parse the expression if there is an "Equal" or "Solve" or "Apply" at the root
-    // TODO: Handle nested "Equal", "Solve", "Apply"s. For example, 3x=5 -> computed solution goes here = numerical solution goes here
     if (command.expression[0] == 'Equal') {
       // TODO: If the expression is only a single getter or something simple, don't call the CAS
       pythonExpression = `${expressionToPython(innerExpression)}\n\t.subs({${substitutions}})\n\t.evalf()`

--- a/src/cas/pyodide-cas.ts
+++ b/src/cas/pyodide-cas.ts
@@ -372,6 +372,7 @@ export function usePyodide() {
     const symbolNames = Array.from(getterNames).map((key) => encodeName(key))
 
     const substitutions = Array.from(command.gettersData.entries())
+      .filter(([key, _]) => getterNames.has(key)) // Only substitute those that actually appear in the expression
       .map(([key, value]) => `${encodeName(key)}:${expressionToPython(value)}`)
       .join(',')
 

--- a/src/model/document/elements/expression-element.ts
+++ b/src/model/document/elements/expression-element.ts
@@ -151,34 +151,6 @@ export class ExpressionElement extends QuantumElement {
     if (!gettersData) {
       return
     }
-    /**
-     * TODO: Where do I document this?
-     * Expression:
-["top level CAS command", actual expression]
-
-Actual expression:
-- Has some direct getters (e.g. 3x+5+1 has `x` as a getter)
-- Those direct getters are either 
-  - symbols (undefined, so then 3x+5+1 would be equal to 3x+6) 
-  - reference some value (e.g. 7, so then 3x+5+1 would be equal to 27)
-  - reference some value with symbols (e.g. 7cm, so then 3x+5+1 would be equal to 21cm+6)
-     */
-
-    // TODO:
-    /*
-      - Topmost can optionally be ["Assign", variables, executeable-expression]
-        - Variables can be "variable" or ["???", "variable", "variable", ...]
-          - Variables will always remain sorted!
-        
-        - Executeable Expression topmost can optionally be
-          - ["Equal", executeable-expression, options, ["Result???", null|result]] = (but only use 2 decimal places) = cm = m
-          - ["Solve", executeable-expression, options, ["Result???", null|result]] --solve, n-->
-          - ["Apply", executeable-expression, options, ["Result???", null|result]] | apply *3 | apply +2
-          - Or it can be a simple-expression
-        
-        - Simple Expression can contain 
-          - "Add", "Subtract", "Multiply", "Divide", ===, <, and so on
-      */
 
     const self = this
     // TODO: Fix c:=8+4=

--- a/src/model/document/elements/expression-element.ts
+++ b/src/model/document/elements/expression-element.ts
@@ -3,11 +3,11 @@ import { ref, Ref, watch, reactive, shallowRef, computed, watchEffect, shallowRe
 import { UseScopedVariable, UseScopedGetter, ScopeElementType } from './scope-element'
 import { cas } from '../../cas'
 import { assert } from '../../assert'
-import { CasCommand } from '../../../cas/cas'
+import { CasCommand, CasExpression } from '../../../cas/cas'
 import { getGetterNames } from '../../../cas/cas-math'
 import { Expression, match, substitute } from '@cortex-js/compute-engine'
 import { Vector2 } from '../../vectors'
-import { handleExpressionValue } from './../../../cas/mathjson-utils'
+import { getExpressionValue, handleExpressionValue } from './../../../cas/mathjson-utils'
 
 export const ElementType = 'expression-element'
 
@@ -19,7 +19,7 @@ export class ExpressionElement extends QuantumElement {
   readonly getters: Map<string, UseScopedGetter> = shallowReactive(new Map<string, UseScopedGetter>())
   readonly variables: Map<string, UseScopedVariable> = shallowReactive(new Map<string, UseScopedVariable>())
 
-  private readonly runningCasExpression: Ref<CasCommand | undefined> = shallowRef()
+  private readonly runningCasCommand: Ref<CasCommand | undefined> = shallowRef()
   private readonly blockPosition = computed(() => this.position.value)
 
   constructor(options: QuantumElementCreationOptions) {
@@ -29,8 +29,8 @@ export class ExpressionElement extends QuantumElement {
       // Remove getters and variables when the scope changes
       this.updateGetters(new Set<string>())
       this.updateVariables(new Set<string>())
-      if (this.runningCasExpression.value) {
-        cas.cancelCommand(this.runningCasExpression.value)
+      if (this.runningCasCommand.value) {
+        cas.cancelCommand(this.runningCasCommand.value)
       }
 
       // If we have a new scope, recompute
@@ -141,9 +141,76 @@ export class ExpressionElement extends QuantumElement {
     })
   }
 
+  /**
+   * Returns `true` if it's an "Equal" or "Evaluate" expression.
+   */
+  private isCasExpression(expression: Expression): expression is CasExpression {
+    // Woah, user defined type guards are fancy https://2ality.com/2020/06/type-guards-assertion-functions-typescript.html#user-defined-type-guards
+    const value = getExpressionValue(expression)
+    if (value.type === 'function') {
+      const { head } = value.value
+      if (head === 'Equal' || head === 'Evaluate') {
+        return true
+      }
+    }
+    return false
+  }
+
+  private executeCasExpression(
+    expression: CasExpression,
+    gettersData: Map<string, Expression<number>>,
+    callback: (result: any | null, resultingExpression: Expression) => void
+  ) {
+    const value = getExpressionValue(expression)
+    assert(value.type === 'function', 'Expected a function expression')
+
+    // Test for nested CAS expressions. This relies on all CAS expressions being ["something", stuff to eval, "Missing"]
+    if (this.isCasExpression(expression[1])) {
+      this.executeCasExpression(expression[1], gettersData, (result, resultingExpression) => {
+        // Show that expression (callback can get called multiple times for that reason)
+        expression = expression.slice() as CasExpression
+        expression[1] = resultingExpression // TODO: This can result in more getters existing https://github.com/stefnotch/quantum-sheet/issues/40
+        callback(null, expression)
+
+        const computeExpression = expression.slice() as CasExpression
+        computeExpression[1] = result
+        // And now compute a bit more
+        this.runningCasCommand.value = new CasCommand(
+          gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
+          computeExpression,
+          (result) => {
+            const output = expression.slice()
+            if (expression[0] === 'Evaluate') {
+              output[3] = ['\\mathinner', result] // ["Evaluate", lhs, solve arguments, rhs]
+            } else {
+              output[2] = ['\\mathinner', result] // A part of the expression, namely the one with the placeholder, gets replaced
+            }
+            callback(result, output)
+          }
+        )
+        cas.executeCommand(this.runningCasCommand.value)
+      })
+    } else {
+      this.runningCasCommand.value = new CasCommand(
+        gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
+        expression,
+        (result) => {
+          const output = expression.slice()
+          if (expression[0] === 'Evaluate') {
+            output[3] = ['\\mathinner', result] // ["Evaluate", lhs, solve arguments, rhs]
+          } else {
+            output[2] = ['\\mathinner', result] // A part of the expression, namely the one with the placeholder, gets replaced
+          }
+          callback(result, output)
+        }
+      )
+      cas.executeCommand(this.runningCasCommand.value)
+    }
+  }
+
   private evaluateLater() {
-    if (this.runningCasExpression.value) {
-      cas.cancelCommand(this.runningCasExpression.value)
+    if (this.runningCasCommand.value) {
+      cas.cancelCommand(this.runningCasCommand.value)
     }
 
     if (!this.hasExpression) return
@@ -153,85 +220,43 @@ export class ExpressionElement extends QuantumElement {
       return
     }
 
-    const self = this
-    // TODO: Fix c:=8+4=
-    function evaluateExpression(expression: any, callback: (result: any) => void) {
-      if (Array.isArray(expression)) {
-        const functionName = expression[0]
-        if (functionName == 'Equal') {
-          evaluateExpression(expression[1], (result) => {
-            const casExpression = expression.slice()
-            casExpression[1] = result
+    // TODO: What about very nested evaluate signs? Like `a:=(1+2=)^2`
 
-            self.runningCasExpression.value = new CasCommand(
-              gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
-              casExpression,
-              (result) => {
-                // TODO: Fix this for nested equals signs/expressions
-                const output = expression.slice()
-                output[2] = ['\\mathinner', result] // A part of the expression, namely the one with the placeholder, gets replaced
-                self.expression.value = output
-                callback(result)
-              }
-            )
-            cas.executeCommand(self.runningCasExpression.value)
-          })
-        } else if (functionName == 'Evaluate') {
-          evaluateExpression(expression[1], (result) => {
-            const casExpression = expression.slice()
-            casExpression[1] = result
+    const value = getExpressionValue(this.expression.value)
+    if (value.type === 'function') {
+      const { head, args } = value.value
 
-            self.runningCasExpression.value = new CasCommand(
-              gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
-              casExpression,
-              (result) => {
-                // TODO: Fix this for nested equals signs/expressions
-                const output = expression.slice()
-                output[3] = ['\\mathinner', result]
-                self.expression.value = output
-                callback(result)
-              }
-            )
-            cas.executeCommand(self.runningCasExpression.value)
+      if (head === 'Assign') {
+        // Only top-level assignments are supported
+        // Everything else is probably an assignment to a variable that only exists inside the expression (e.g. $\sum_{i:=1}^n$)
+        const innerExpression = args[1]
+
+        if (this.isCasExpression(innerExpression)) {
+          // e.g. a := 3+5 =
+          this.executeCasExpression(innerExpression, gettersData, (result, resultingExpression) => {
+            this.expression.value = [head, args[0], resultingExpression]
+
+            // TODO: Support assigning to multiple variables
+            assert(this.variables.size === 1, 'Assigning to multiple variables not supported yet')
+            this.variables.forEach((v) => v.setData(result))
           })
-        } else if (functionName == 'Apply') {
-          // TODO:
         } else {
-          callback(expression)
+          // e.g. a := 3
+          this.executeCasExpression(['Evaluate', innerExpression, 'Missing', 'Missing'], gettersData, (result, _) => {
+            // TODO: Support assigning to multiple variables
+            assert(this.variables.size === 1, 'Assigning to multiple variables not supported yet')
+            this.variables.forEach((v) => v.setData(result))
+          })
         }
-      } else {
-        callback(expression)
+      } else if (this.isCasExpression(this.expression.value)) {
+        // e.g. 3+5 =
+        assert(this.variables.size === 0, 'Expected no variables')
+        this.executeCasExpression(this.expression.value, gettersData, (_, resultingExpression) => {
+          this.expression.value = resultingExpression
+        })
       }
-    }
-
-    handleExpressionValue(this.expression.value, {
-      function: (value) => {
-        if (typeof value.head !== 'string') return
-
-        // Maybe don't hardcode this here, it seems like it'd be worth documenting *somewhere*
-        if (value.head == 'Assign') {
-          evaluateExpression(value.args[1], (result) => {
-            this.runningCasExpression.value = new CasCommand(
-              gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
-              ['Equal', result, null],
-              (result) => {
-                // TODO: Support assigning to multiple variables
-                assert(this.variables.size === 1, 'Assigning to multiple variables not supported yet')
-                this.variables.forEach((v) => v.setData(result))
-              }
-            )
-            cas.executeCommand(this.runningCasExpression.value)
-          })
-        } else {
-          assert(this.variables.size === 0, 'Expected no variables')
-          evaluateExpression(this.expression.value, (result) => {})
-        }
-      },
-    })
-
-    if (Array.isArray(this.expression.value) && this.expression.value[0] == 'Assign') {
     } else {
-      evaluateExpression(this.expression.value, (result) => {})
+      // Not a function, do nothing
     }
   }
 }

--- a/src/model/document/elements/expression-element.ts
+++ b/src/model/document/elements/expression-element.ts
@@ -8,6 +8,7 @@ import { getGetterNames } from '../../../cas/cas-math'
 import { Expression, match, substitute } from '@cortex-js/compute-engine'
 import { Vector2 } from '../../vectors'
 import { getExpressionValue, handleExpressionValue } from './../../../cas/mathjson-utils'
+import * as Notification from '../../../ui/notification'
 
 export const ElementType = 'expression-element'
 
@@ -179,6 +180,12 @@ export class ExpressionElement extends QuantumElement {
           gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
           computeExpression,
           (result) => {
+            if (result instanceof Error) {
+              // TODO: Show the errors inline instead of using a big notification
+              Notification.error('CAS error', result.message)
+              result = ['Error', 'Missing', { str: (result.message + '').slice(0, 40) }] // Put 'error' to right of equal sign
+            }
+
             const output = expression.slice()
             if (expression[0] === 'Evaluate') {
               output[3] = ['\\mathinner', result] // ["Evaluate", lhs, solve arguments, rhs]
@@ -195,6 +202,11 @@ export class ExpressionElement extends QuantumElement {
         gettersData, // TODO: Don't pass in all getters (or pass in a reference to the getters?)
         expression,
         (result) => {
+          if (result instanceof Error) {
+            // TODO: Show the errors inline instead of using a big notification
+            Notification.error('CAS error', result.message)
+            result = ['Error', 'Missing', { str: (result.message + '').slice(0, 40) }] // Put 'error' to right of equal sign
+          }
           const output = expression.slice()
           if (expression[0] === 'Evaluate') {
             output[3] = ['\\mathinner', result] // ["Evaluate", lhs, solve arguments, rhs]

--- a/src/model/document/elements/expression-element.ts
+++ b/src/model/document/elements/expression-element.ts
@@ -49,6 +49,26 @@ export class ExpressionElement extends QuantumElement {
   }
 
   /**
+   * Gets all the data from every getter
+   * @returns The expressions or undefined if at least one getter doesn't have its value
+   */
+  private getGettersData() {
+    const gettersData = new Map<string, Expression>()
+    for (const [name, getter] of this.getters) {
+      const data = getter.data.value
+      if (data === undefined) {
+        // It's a symbol
+      } else if (data === null) {
+        // Variable is missing its data
+        return
+      } else {
+        gettersData.set(name, data)
+      }
+    }
+    return gettersData
+  }
+
+  /**
    * User expression input
    * @param value Expression that the user typed
    */
@@ -127,24 +147,22 @@ export class ExpressionElement extends QuantumElement {
 
     if (!this.hasExpression) return
 
-    // Check if all getters that should have a value actually do have a value
-    const gettersData = new Map<string, any>()
-    let allDataDefined = true
-    this.getters.forEach((value, key) => {
-      const data = value.data.value
-      if (data === undefined) {
-        // It's a symbol
-      } else if (data === null) {
-        // Variable is missing its data
-        allDataDefined = false
-      } else {
-        gettersData.set(key, data)
-      }
-    })
-
-    if (!allDataDefined || !this.expression.value) {
+    const gettersData = this.getGettersData()
+    if (!gettersData) {
       return
     }
+    /**
+     * TODO: Where do I document this?
+     * Expression:
+["top level CAS command", actual expression]
+
+Actual expression:
+- Has some direct getters (e.g. 3x+5+1 has `x` as a getter)
+- Those direct getters are either 
+  - symbols (undefined, so then 3x+5+1 would be equal to 3x+6) 
+  - reference some value (e.g. 7, so then 3x+5+1 would be equal to 27)
+  - reference some value with symbols (e.g. 7cm, so then 3x+5+1 would be equal to 21cm+6)
+     */
 
     // TODO:
     /*

--- a/src/model/document/elements/scope-element.ts
+++ b/src/model/document/elements/scope-element.ts
@@ -4,6 +4,7 @@ import { Vector2 } from '../../vectors'
 import arrayUtils from '../../array-utils'
 import { assert } from '../../assert'
 import { watchImmediate } from '../../reactivity-utils'
+import type { Expression } from '@cortex-js/compute-engine'
 
 export const ElementType = 'scope-element'
 
@@ -121,7 +122,7 @@ export class ScopeElement extends QuantumElement {
       }
     )
 
-    function setData(data: any) {
+    function setData(data: Expression | null | undefined) {
       variable.data = data
     }
 
@@ -228,7 +229,7 @@ export interface UseScopedVariable {
    * - `null` is a variable without data
    * - anything else is data
    */
-  setData(data: any): void // TODO: Use MathJson type
+  setData(data: Expression | null | undefined): void
   remove(): void
 }
 
@@ -238,7 +239,7 @@ export interface UseScopedGetter {
    * - `null` is a variable without data
    * - anything else is data
    */
-  data: ComputedRef<any>
+  data: ComputedRef<Expression | null | undefined>
   remove(): void
 }
 

--- a/src/model/mathjson-custom-dictionary.ts
+++ b/src/model/mathjson-custom-dictionary.ts
@@ -31,6 +31,7 @@ export const dictionary = LatexSyntax.getDictionary() as LatexDictionary<any> //
 
 // `a == b =` should be parsed as `(a == b) =`
 // Basically, it should first check whether the two are equivalent and then calculate the result
+// TODO: Add solve argument
 dictionary.find((v) => v.name === 'EqualEqual')!.precedence = 265
 
 dictionary.find((v) => v.name === 'Equal')!.associativity = 'left'


### PR DESCRIPTION
This fixes some bugs regarding the parsing of expressions. For example, now `a := 3+5 = ` is supported.
It also improves the code and documentation a little bit.