### PR TITLE
Bundle of minor improvements.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "quantum-sheet",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@ant-design/icons-vue": "^6.0.1",
@@ -15,6 +15,7 @@
         "browser-fs-access": "^0.20.4",
         "idb-keyval": "^5.1.3",
         "interactjs": "^1.10.11",
+        "lodash": "^4.17.21",
         "mathlive": "0.69.5",
         "selecto": "^1.12.1",
         "uuid": "^8.3.2",
@@ -2453,6 +2454,7 @@
       "resolved": "https://registry.npmjs.org/css-styled/-/css-styled-1.0.0.tgz",
       "integrity": "sha512-lDdPvM2/djv+La110zVY3RGQ7X4OOlzLS+IEjRcn8UlUmJd1+GNcGfDFmsKWwnLBupsY1w0QM1gRgV4RdcCjfw==",
       "requires": {
+        "@daybrush/utils": "^1.0.0",
         "string-hash": "^1.1.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "browser-fs-access": "^0.20.4",
     "idb-keyval": "^5.1.3",
     "interactjs": "^1.10.11",
-    "lodash": "^4.17.21",
     "mathlive": "0.69.5",
     "selecto": "^1.12.1",
     "uuid": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "browser-fs-access": "^0.20.4",
     "idb-keyval": "^5.1.3",
     "interactjs": "^1.10.11",
+    "lodash": "^4.17.21",
     "mathlive": "0.69.5",
     "selecto": "^1.12.1",
     "uuid": "^8.3.2",

--- a/public/mathjson.py
+++ b/public/mathjson.py
@@ -221,7 +221,7 @@ class MathJsonPrinter(Printer):
     # TODO: Important Update
     def _print_Exp1(self, expr):
         print("Warning: _print_Exp1 was called")
-        return 'E'
+        return self._print('"ExponentialE"')
 
     # TODO: Update
     def _print_ExprCondPair(self, expr):

--- a/src/App.vue
+++ b/src/App.vue
@@ -114,6 +114,12 @@ export default defineComponent({
     top: 0;
     margin-top: 0px !important;
     margin-bottom: 0px !important;
+    margin-left: 0px !important;
+    margin-right: 0px !important;
+  }
+  .page-divider * {
+    visibility: hidden;
+    display: none;
   }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,7 +69,7 @@ export default defineComponent({
   background-color: #f1f1f1;
   display: flex;
   /* Header and footer */
-  overflow-y: scroll;
+  overflow-y: auto;
   height: calc(100vh - 36px - 36px);
   /* Sides */
   padding-left: 12px;

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, provide, nextTick, onMounted, Ref } from 'vue'
+import { Button, Layout, LayoutContent, Grid, Row, Col, Space } from 'ant-design-vue'
 import pkg from './../package.json'
 import QuantumDocument from './ui/QuantumDocument.vue'
 import Header from './ui/Header.vue'
@@ -39,6 +40,8 @@ export default defineComponent({
     QuantumDocument,
     Header,
     Footer,
+    'a-layout': Layout,
+    'a-layout-content': LayoutContent
   },
   setup(props, context) {
     if (import.meta.env.PROD) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <a-layout>
     <Header />
     <a-layout class="content">
-      <a-layout-content class="drawingtable center">
+      <a-layout-content class="drawingtable center print-area">
         <!-- TODO: Add an "id" property (with a uuid) so that we can recreate the document whenever we want a new document -->
         <quantum-document @quantum-document="(v) => docManager.registerQuantumDocument(v)"></quantum-document>
         <!-- <LandingPage /> -->
@@ -97,5 +97,23 @@ export default defineComponent({
 .center {
   margin-left: auto;
   margin-right: auto;
+}
+</style>
+
+<style>
+@media print {
+  body * {
+    visibility: hidden;
+  }
+  .print-area * {
+    visibility: visible;
+  }
+  .print-area {
+    position: absolute;
+    left: 0;
+    top: 0;
+    margin-top: 0px !important;
+    margin-bottom: 0px !important;
+  }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,12 +69,12 @@ export default defineComponent({
   background-color: #f1f1f1;
   display: flex;
   /* Header and footer */
-  padding-top: 36px;
-  padding-bottom: 36px;
+  overflow-y: scroll;
+  height: calc(100vh - 36px - 36px);
   /* Sides */
   padding-left: 12px;
   padding-right: 12px;
-  overflow: auto;
+  overflow-x: auto;
 }
 
 .drawingtable {

--- a/src/cas/pyodide-cas.ts
+++ b/src/cas/pyodide-cas.ts
@@ -155,11 +155,16 @@ function usePythonConverter() {
     ['Erf', () => 'sympy.erf'], // TODO: test
     ['Erfc', () => 'sympy.erfc'], // TODO: test
 
+    ['Factorial', () => 'sympy.factorial'],
+
+    // ['Equivalent', () => 'sympy.Equivalent'],
+
     // TODO: MathLive latex serial/parse destroys ln,log, etc? in ExpressionElement.vue line 78
     // ['log', () => 'sympy.log'],
   ])
 
   const KnownLatexFunctions = {
+    // TODO: replace with custom parser in new compute engine
     '\\sin': 'sympy.sin',
     '\\cot': 'sympy.cot',
     '\\arcctg': 'sympy.acot',

--- a/src/main.js
+++ b/src/main.js
@@ -3,12 +3,10 @@ import App from './App.vue'
 import './index.css'
 import { cas } from './model/cas'
 
-import Antd from 'ant-design-vue'
 import 'ant-design-vue/dist/antd.css'
 
 const app = createApp(App)
 
-app.use(Antd)
 app.mount('#app')
 
 cas.doneLoading.then(() => {}) // Load the CAS as early as possible

--- a/src/model/document/document.ts
+++ b/src/model/document/document.ts
@@ -124,7 +124,7 @@ function useElementList() {
 
   /** Watches an element's position. Returns a function to stop the watcher. */
   function watchElement(element: QuantumElement) {
-    const stopWatcher = watchImmediate(element.position, (value) => {
+    const stopWatcher = watchImmediate(element.position, (value: Vector2) => {
       // New index
       let { index } = arrayUtils.getBinaryInsertIndex(elements, (a) => a.position.value.compareTo(value))
 
@@ -179,7 +179,7 @@ function useElementSelection() {
   const selectedElements = shallowReactive<Set<QuantumElement>>(new Set())
 
   function watchElement(element: QuantumElement) {
-    const stopHandle = watchImmediate(element.selected, (value) => {
+    const stopHandle = watchImmediate(element.selected, (value: Boolean) => {
       if (value) {
         selectedElements.add(element)
       } else {
@@ -194,7 +194,7 @@ function useElementSelection() {
   }
 
   function setSelection(...elements: QuantumElement[]) {
-    selectedElements.forEach((e) => e.setSelected(false))
+    selectedElements.forEach((e: QuantumElement) => e.setSelected(false))
     elements.forEach((e) => e.setSelected(true))
   }
 
@@ -209,7 +209,7 @@ function useElementFocus() {
   const focusedElement = shallowRef<QuantumElement>()
 
   function watchElement(element: QuantumElement) {
-    const stopHandle = watchImmediate(element.focused, (value) => {
+    const stopHandle = watchImmediate(element.focused, (value: Boolean) => {
       if (value) {
         if (focusedElement.value?.focused) {
           focusedElement.value.setFocused(false)
@@ -299,7 +299,7 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
   }
 
   function getElementById<T extends keyof TElements>(id: string, typeName?: T): GetQuantumElement<TElements[T]> | undefined {
-    let element = elementList.elements.find((e) => e.id == id)
+    let element = elementList.elements.find((e: QuantumElement) => e.id == id)
     if (element && typeName && element.typeName != typeName) {
       throw new Error(`Wrong type, passed ${typeName} but element has ${element.typeName}`)
     }
@@ -309,7 +309,7 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
   }
 
   function getElementsByType<T extends keyof TElements>(typeName: T): GetQuantumElement<TElements[T]>[] | undefined {
-    let elements = elementList.elements.filter((e) => e.typeName == typeName)
+    let elements = elementList.elements.filter((e: QuantumElement) => e.typeName == typeName)
 
     // Yeah, Typescript really does dislike this XD
     return elements as any[]

--- a/src/model/document/document.ts
+++ b/src/model/document/document.ts
@@ -111,7 +111,7 @@ export interface UseQuantumDocument<TElements extends QuantumDocumentElementType
   /**
    * Move selected Elements by specified distance
    */
-  moveSelectedElements(delta: Vector2): void
+  moveSelectedElements(delta: Vector2, limit?: Vector2): void
 }
 
 /**
@@ -346,20 +346,31 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
     })
   }
 
-  function moveElementsByID(elements: QuantumElement[], delta: Vector2) {
+  function moveElementsByID(elements: QuantumElement[], delta: Vector2, limit?: Vector2) {
     // TODO: dont let it move outside sheet (thus no longer needing 'interact.modifiers.restrict'?)
-    elements.forEach((element) => {
+    let limited = false
+    elements.forEach((element: QuantumElement) => {
+      let newPos = element?.position.value.add(delta)
+      if (limit) {
+        if (
+          newPos.x < 0 ||
+          newPos.y < 0 ||
+          limit.subtract(newPos.add(element.size.value)).x < 0 ||
+          limit.subtract(newPos.add(element.size.value)).y < 0
+        ) {
+          limited = true
+        }
+      }
+    })
+    if (limited) return
+    elements.forEach((element: QuantumElement) => {
       let newPos = element?.position.value.add(delta)
       if (newPos) element?.setPosition(newPos)
     })
   }
 
-  function moveSelectedElements(delta: Vector2) {
-    // TODO: dont let it move outside sheet (thus no longer needing 'interact.modifiers.restrict'?)
-    elementSelection.selectedElements.forEach((element) => {
-      let newPos = element?.position.value.add(delta)
-      if (newPos) element?.setPosition(newPos)
-    })
+  function moveSelectedElements(delta: Vector2, limit?: Vector2) {
+    moveElementsByID(elementSelection.selectedElements, delta, limit)
   }
 
   return {

--- a/src/model/document/document.ts
+++ b/src/model/document/document.ts
@@ -179,7 +179,7 @@ function useElementSelection() {
   const selectedElements = shallowReactive<Set<QuantumElement>>(new Set())
 
   function watchElement(element: QuantumElement) {
-    const stopHandle = watchImmediate(element.selected, (value: Boolean) => {
+    const stopHandle = watchImmediate(element.selected, (value: boolean) => {
       if (value) {
         selectedElements.add(element)
       } else {

--- a/src/model/document/document.ts
+++ b/src/model/document/document.ts
@@ -356,7 +356,7 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
 
   function moveSelectedElements(delta: Vector2) {
     // TODO: dont let it move outside sheet (thus no longer needing 'interact.modifiers.restrict'?)
-    elementList.elements.forEach((element) => {
+    elementSelection.selectedElements.forEach((element) => {
       let newPos = element?.position.value.add(delta)
       if (newPos) element?.setPosition(newPos)
     })

--- a/src/model/document/document.ts
+++ b/src/model/document/document.ts
@@ -102,6 +102,16 @@ export interface UseQuantumDocument<TElements extends QuantumDocumentElementType
    * Deserialize a document's elements
    */
   deserializeDocument(serializedData: JsonType): void
+
+  /**
+   * Move specified Elements by specified distance
+   */
+  moveElementsByID(elements: QuantumElement[], delta: Vector2): void
+
+  /**
+   * Move selected Elements by specified distance
+   */
+  moveSelectedElements(delta: Vector2): void
 }
 
 /**
@@ -336,6 +346,22 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
     })
   }
 
+  function moveElementsByID(elements: QuantumElement[], delta: Vector2) {
+    // TODO: dont let it move outside sheet (thus no longer needing 'interact.modifiers.restrict'?)
+    elements.forEach((element) => {
+      let newPos = element?.position.value.add(delta)
+      if (newPos) element?.setPosition(newPos)
+    })
+  }
+
+  function moveSelectedElements(delta: Vector2) {
+    // TODO: dont let it move outside sheet (thus no longer needing 'interact.modifiers.restrict'?)
+    elementList.elements.forEach((element) => {
+      let newPos = element?.position.value.add(delta)
+      if (newPos) element?.setPosition(newPos)
+    })
+  }
+
   return {
     options,
     elementTypes: elementTypes,
@@ -347,6 +373,8 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
     getSelection: () => [...elementSelection.selectedElements],
     setSelection: elementSelection.setSelection,
     setFocus: elementFocus.setFocus,
+    moveElementsByID,
+    moveSelectedElements,
 
     serializeDocument,
     deserializeDocument,

--- a/src/model/document/document.ts
+++ b/src/model/document/document.ts
@@ -106,7 +106,7 @@ export interface UseQuantumDocument<TElements extends QuantumDocumentElementType
   /**
    * Move specified Elements by specified distance
    */
-  moveElementsByID(elements: QuantumElement[], delta: Vector2): void
+  moveElements(elements: QuantumElement[], delta: Vector2): void
 
   /**
    * Move selected Elements by specified distance
@@ -346,7 +346,7 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
     })
   }
 
-  function moveElementsByID(elements: QuantumElement[], delta: Vector2, limit?: Vector2) {
+  function moveElements(elements: QuantumElement[], delta: Vector2, limit?: Vector2) {
     // TODO: dont let it move outside sheet (thus no longer needing 'interact.modifiers.restrict'?)
     let limited = false
     elements.forEach((element: QuantumElement) => {
@@ -370,7 +370,7 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
   }
 
   function moveSelectedElements(delta: Vector2, limit?: Vector2) {
-    moveElementsByID(elementSelection.selectedElements, delta, limit)
+    moveElements(elementSelection.selectedElements, delta, limit)
   }
 
   return {
@@ -384,7 +384,7 @@ export function useDocument<TElements extends QuantumDocumentElementTypes<readon
     getSelection: () => [...elementSelection.selectedElements],
     setSelection: elementSelection.setSelection,
     setFocus: elementFocus.setFocus,
-    moveElementsByID,
+    moveElements,
     moveSelectedElements,
 
     serializeDocument,

--- a/src/ui/Footer.vue
+++ b/src/ui/Footer.vue
@@ -12,9 +12,10 @@
               :danger="UI.casStatus.casState.value === 'error'"
               @click="appActions.compute"
             >
-              <!-- <CalculatorOutlined /> -->
-              <!-- <a-icon :type="UI.casStatus.icon.value" /> -->
-              <Icon :icon="UI.casStatus.casIcon.value" :id="UI.casStatus.casIcon.value" />
+              <CalculatorOutlined v-if="UI.casStatus.casState.value == 'ready'" />
+              <ApiOutlined v-else-if="UI.casStatus.casState.value == 'disconnected'" />
+              <LoadingOutlined v-else-if="UI.casStatus.casState.value == 'loading'" />
+              <WarningOutlined v-else-if="UI.casStatus.casState.value == 'error'" />
             </a-button>
           </a-tooltip>
           <!-- Auto Calculate -->
@@ -108,10 +109,10 @@
 
 <script lang="ts">
 import { defineComponent, ref, reactive, inject, watch } from 'vue'
-import { ExportOutlined, CalculatorOutlined, AppstoreOutlined } from '@ant-design/icons-vue'
+import { Button, Grid, Row, Col, Space, Dropdown, Select, SelectOption, Modal } from 'ant-design-vue'
+import { ExportOutlined, CalculatorOutlined, AppstoreOutlined, ApiOutlined, LoadingOutlined, WarningOutlined } from '@ant-design/icons-vue'
 import * as UI from './ui'
 import * as Notification from './notification'
-import { Icon } from './icon'
 import { cas } from './../model/cas'
 
 function useDocActions() {
@@ -155,7 +156,18 @@ export default defineComponent({
     ExportOutlined,
     CalculatorOutlined,
     AppstoreOutlined,
-    Icon,
+    ApiOutlined,
+    LoadingOutlined,
+    WarningOutlined,
+    'a-row': Row,
+    'a-col': Col,
+    'a-grid': Grid,
+    'a-space': Space,
+    'a-dropdown': Dropdown,
+    'a-select': Select,
+    'a-select-option': SelectOption,
+    'a-button': Button,
+    'a-modal': Modal,
   },
   props: {},
   setup(props, context) {
@@ -166,7 +178,6 @@ export default defineComponent({
     cas.doneLoading.then(
       () => {
         // TODO: Maybe make this notification a bit more subtle? And instead make the loading indicator somewhat more obvious?
-        Notification.notify('success', 'Pyodide worker created', 'You can use QuantumSheet now')
         UI.casStatus.setReady()
       },
       (error) => {

--- a/src/ui/Header.vue
+++ b/src/ui/Header.vue
@@ -183,7 +183,6 @@ export default defineComponent({
 
 <style scoped>
 .header {
-  position: fixed;
   z-index: 1;
   width: 100%;
   box-shadow: 0px 0px 5px 0.1px #ccc;

--- a/src/ui/Header.vue
+++ b/src/ui/Header.vue
@@ -126,6 +126,23 @@
 
 <script lang="ts">
 import { defineComponent, ref, inject, reactive } from 'vue'
+import {
+  Button,
+  Grid,
+  Row,
+  Col,
+  Space,
+  Dropdown,
+  Select,
+  SelectOption,
+  Form,
+  FormItem,
+  Modal,
+  Menu,
+  MenuItem,
+  UploadDragger,
+  Textarea,
+} from 'ant-design-vue'
 import { InboxOutlined, DownloadOutlined } from '@ant-design/icons-vue'
 import pkg from '../../package.json'
 
@@ -136,6 +153,21 @@ export default defineComponent({
   components: {
     InboxOutlined,
     DownloadOutlined,
+    'a-row': Row,
+    'a-col': Col,
+    'a-grid': Grid,
+    'a-space': Space,
+    'a-dropdown': Dropdown,
+    'a-select': Select,
+    'a-select-option': SelectOption,
+    'a-form': Form,
+    'a-form-item': FormItem,
+    'a-button': Button,
+    'a-modal': Modal,
+    'a-menu': Menu,
+    'a-menu-item': MenuItem,
+    'a-upload-dragger': UploadDragger,
+    'a-textarea': Textarea,
   },
   setup(props, context) {
     // const UI = useUI()

--- a/src/ui/Header.vue
+++ b/src/ui/Header.vue
@@ -1,8 +1,8 @@
 <template>
   <header class="header">
     <a-row type="flex" justify="space-between" :style="{ height: '36px', lineHeight: '36px', paddingLeft: '20px' }">
-      <a-col :span="4">
-        <a-space :style="{ height: '36px', alignItems: 'revert' }">
+      <a-col :span="8" :style="{ height: '36px' }">
+        <a-space :style="{ height: '36px', alignItems: 'revert', gap: '0px' }" :size="0">
           <div :style="{ width: '10px' }" />
           <h3 @click="() => {}" :style="{ cursor: 'pointer', margin: 0, width: '110px' }">QuantumSheet</h3>
           <div :style="{ width: '16px' }" />
@@ -38,7 +38,7 @@
         </a-space>
       </a-col>
 
-      <a-col>
+      <a-col :style="{ height: '36px' }">
         <a-space :style="{ height: '36px' }">
           <p>v{{ pkg.version }} - <a href="https://github.com/stefnotch/quantum-sheet">View on GitHub</a></p>
           <div :style="{ width: '20px' }" />

--- a/src/ui/Header.vue
+++ b/src/ui/Header.vue
@@ -19,6 +19,9 @@
                 <a-menu-item @click="UI.fileInterface.openFileSaveModal()">
                   <a :style="{ color: 'black' }">Save as...</a>
                 </a-menu-item>
+                <a-menu-item @click="print()">
+                  <a :style="{ color: 'black' }">Print...</a>
+                </a-menu-item>
                 <!-- <a-menu-item @click="UI.promptCloseFile()">
                   <a :style="{ color: 'black' }">Close</a>
                 </a-menu-item> -->
@@ -202,12 +205,17 @@ export default defineComponent({
       return false // to prevent antd fron trying to upload somewhere
     }
 
+    function print() {
+      window.print()
+    }
+
     return {
       UI,
       docManager,
       download,
       beforeUpload,
       pkg,
+      print,
     }
   },
 })

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -215,7 +215,6 @@ function useElementSelection<T extends QuantumDocumentElementTypes>(quantumDocum
             // selection-region is the child element, we want the id of the parent, quantum-element
             el = el.parentElement as HTMLElement
           }
-          console.log('selected q-el', quantumDocument.getElementById(el.id))
           quantumDocument.getElementById(el.id)?.setSelected(true)
         })
         e.removed.forEach((el) => {
@@ -223,7 +222,6 @@ function useElementSelection<T extends QuantumDocumentElementTypes>(quantumDocum
             // selection-region is the child element, we want the id of the parent, quantum-element
             el = el.parentElement as HTMLElement
           }
-          console.log('unselected q-el', quantumDocument.getElementById(el.id))
           quantumDocument.getElementById(el.id)?.setSelected(false)
         })
       })
@@ -278,7 +276,6 @@ function useElementDrag<T extends QuantumDocumentElementTypes>(quantumDocument: 
       })
       .on('dragmove', (event) => {
         let delta = new Vector2(event.dx / quantumDocument.options.gridCellSize.x, event.dy / quantumDocument.options.gridCellSize.y)
-        console.log('dragging', quantumDocument.getSelection())
         quantumDocument.moveSelectedElements(delta)
         event.preventDefault()
       })
@@ -370,7 +367,6 @@ function useEvents<T extends QuantumDocumentElementTypes>(
               ArrowUp: new Vector2(0, -1),
               ArrowDown: new Vector2(0, 1),
             }[event.key] ?? Vector2.zero
-          console.log('moving', quantumDocument.getSelection())
           quantumDocument.moveSelectedElements(direction)
         } else {
           grid.keydown(event)

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -110,7 +110,11 @@ function useClipboard<T extends QuantumDocumentElementTypes>(document: UseQuantu
   }
 }
 
-function useGrid<T extends QuantumDocumentElementTypes>(document: UseQuantumDocument<T>, inputElement: Ref<HTMLElement | undefined>) {
+function useGrid<T extends QuantumDocumentElementTypes>(
+  document: UseQuantumDocument<T>,
+  inputElement: Ref<HTMLElement | undefined>,
+  pages: ReturnType<typeof usePages>
+) {
   const crosshairPosition = ref<Vector2>(new Vector2(2, 10))
   const showCrosshair = ref(true)
 
@@ -144,6 +148,15 @@ function useGrid<T extends QuantumDocumentElementTypes>(document: UseQuantumDocu
         ArrowUp: new Vector2(0, -1),
         ArrowDown: new Vector2(0, 1),
       }[ev.key] ?? Vector2.zero
+
+    let limited = false
+    let limit = pages.getPageLimits()
+    let newPos = crosshairPosition.value.add(direction)
+    if (newPos.x < 0 || newPos.y < 0 || limit.subtract(newPos).x < 0 || limit.subtract(newPos).y < 0) {
+      limited = true
+    }
+
+    if (limited) return
 
     crosshairPosition.value = crosshairPosition.value.add(direction)
     focusUnderCrosshair()
@@ -263,13 +276,14 @@ function useElementDrag<T extends QuantumDocumentElementTypes>(quantumDocument: 
           }),
         ],
         inertia: false,
-        autoScroll: {
-          container: document.querySelector('.content') as HTMLElement,
-          margin: 50,
-          distance: 5,
-          interval: 10,
-          speed: 500,
-        },
+        // autoScroll: {
+        //   container: document.querySelector('.content') as HTMLElement,
+        //   margin: 50,
+        //   distance: 5,
+        //   interval: 10,
+        //   speed: 500,
+        // },
+        autoScroll: false,
       })
       .on('down', (event) => {
         dragging = true
@@ -510,8 +524,8 @@ export default defineComponent({
 
     // const UI = useUI()
     const focusedElementCommands = useFocusedElementCommands()
-    const grid = useGrid(document, documentInputElement)
     const pages = usePages(document)
+    const grid = useGrid(document, documentInputElement, pages)
     const clipboard = useClipboard(document)
     const selection = useElementSelection(document)
     const elementDrag = useElementDrag(document, pages)

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -276,17 +276,20 @@ function useElementDrag<T extends QuantumDocumentElementTypes>(quantumDocument: 
           }),
         ],
         inertia: false,
-        // autoScroll: {
-        //   container: document.querySelector('.content') as HTMLElement,
-        //   margin: 50,
-        //   distance: 5,
-        //   interval: 10,
-        //   speed: 500,
-        // },
-        autoScroll: false,
+        autoScroll: {
+          container: document.querySelector('.content') as HTMLElement,
+          margin: 50,
+          distance: 5,
+          interval: 10,
+          speed: 500,
+        },
+        // autoScroll: false,
       })
       .on('down', (event) => {
         dragging = true
+        let target = document.querySelector('.content') as HTMLElement
+        previousScrollLeft = target.scrollLeft
+        previousScrollTop = target.scrollTop
       })
       .on('dragmove', (event) => {
         let delta = new Vector2(event.dx / quantumDocument.options.gridCellSize.x, event.dy / quantumDocument.options.gridCellSize.y)
@@ -301,11 +304,11 @@ function useElementDrag<T extends QuantumDocumentElementTypes>(quantumDocument: 
 
     document.querySelector('.content')?.addEventListener('scroll', function (e) {
       if (e.target && dragging) {
-        let scrollLeft =
-          (e.target as HTMLDivElement).scrollLeft != 0 ? (e.target as HTMLDivElement).scrollLeft / quantumDocument.options.gridCellSize.x : 0
-        let scrollTop =
-          (e.target as HTMLDivElement).scrollTop != 0 ? (e.target as HTMLDivElement).scrollTop / quantumDocument.options.gridCellSize.y : 0
-        let delta = new Vector2(scrollLeft - previousScrollLeft, scrollTop - previousScrollTop)
+        let scrollLeft = (e.target as HTMLDivElement).scrollLeft
+        let scrollTop = (e.target as HTMLDivElement).scrollTop
+        let deltax = scrollLeft - previousScrollLeft != 0 ? (scrollLeft - previousScrollLeft) / quantumDocument.options.gridCellSize.x : 0
+        let deltay = scrollTop - previousScrollTop != 0 ? (scrollTop - previousScrollTop) / quantumDocument.options.gridCellSize.y : 0
+        let delta = new Vector2(deltax, deltay)
         quantumDocument.moveSelectedElements(delta)
 
         previousScrollTop = scrollTop
@@ -467,9 +470,10 @@ function usePages<T extends QuantumDocumentElementTypes>(quantumDocument: UseQua
   }
 
   // Element Added/Removed
-  watch(quantumDocument.elements, (value) => {
-    updatePageCount()
-  })
+  // watch(quantumDocument.elements, (value) => {
+  //   console.log('yoo, something changed')
+  //   updatePageCount()
+  // })
 
   watchImmediate(
     () => quantumDocument.options.paperSize,

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -257,51 +257,51 @@ function useElementDrag<T extends QuantumDocumentElementTypes>(quantumDocument: 
   let previousScrollLeft = 0
   let dragging = false
 
-  nextTick(function () {
-    interact('.quantum-block')
-      .draggable({
-        ignoreFrom: '.quantum-element',
-        modifiers: [
-          interact.modifiers.snap({
-            targets: [interact.snappers.grid({ x: quantumDocument.options.gridCellSize.x, y: quantumDocument.options.gridCellSize.y })],
-            range: Infinity,
-            relativePoints: [{ x: 0, y: 0 }],
-            offset: 'parent',
-            // endOnly: true,
-          }),
-          interact.modifiers.restrict({
-            restriction: '.quantum-document',
-            elementRect: { top: 0, left: 0, bottom: 1, right: 1 },
-            // endOnly: true,
-          }),
-        ],
-        inertia: false,
-        autoScroll: {
-          container: document.querySelector('.content') as HTMLElement,
-          margin: 50,
-          distance: 5,
-          interval: 10,
-          speed: 500,
-        },
-        // autoScroll: false,
-      })
-      .on('down', (event) => {
-        dragging = true
-        let target = document.querySelector('.content') as HTMLElement
-        previousScrollLeft = target.scrollLeft
-        previousScrollTop = target.scrollTop
-      })
-      .on('dragmove', (event) => {
-        let delta = new Vector2(event.dx / quantumDocument.options.gridCellSize.x, event.dy / quantumDocument.options.gridCellSize.y)
-        quantumDocument.moveSelectedElements(delta)
-        // quantumDocument.moveSelectedElements(delta, pages.getPageLimits())
-        event.preventDefault()
-      })
-      .on('dragend', (event) => {
-        pages.updatePageCount()
-        dragging = false
-      })
+  interact('.quantum-block')
+    .draggable({
+      ignoreFrom: '.quantum-element',
+      modifiers: [
+        interact.modifiers.snap({
+          targets: [interact.snappers.grid({ x: quantumDocument.options.gridCellSize.x, y: quantumDocument.options.gridCellSize.y })],
+          range: Infinity,
+          relativePoints: [{ x: 0, y: 0 }],
+          offset: 'parent',
+          // endOnly: true,
+        }),
+        interact.modifiers.restrict({
+          restriction: '.quantum-document',
+          elementRect: { top: 0, left: 0, bottom: 1, right: 1 },
+          // endOnly: true,
+        }),
+      ],
+      inertia: false,
+      autoScroll: {
+        container: document.querySelector('.content') as HTMLElement,
+        margin: 50,
+        distance: 5,
+        interval: 10,
+        speed: 500,
+      },
+      // autoScroll: false,
+    })
+    .on('down', (event) => {
+      dragging = true
+      let target = document.querySelector('.content') as HTMLElement
+      previousScrollLeft = target.scrollLeft
+      previousScrollTop = target.scrollTop
+    })
+    .on('dragmove', (event) => {
+      let delta = new Vector2(event.dx / quantumDocument.options.gridCellSize.x, event.dy / quantumDocument.options.gridCellSize.y)
+      quantumDocument.moveSelectedElements(delta)
+      // quantumDocument.moveSelectedElements(delta, pages.getPageLimits())
+      event.preventDefault()
+    })
+    .on('dragend', (event) => {
+      pages.updatePageCount()
+      dragging = false
+    })
 
+  nextTick(function () {
     document.querySelector('.content')?.addEventListener('scroll', function (e) {
       if (e.target && dragging) {
         let scrollLeft = (e.target as HTMLDivElement).scrollLeft
@@ -470,10 +470,9 @@ function usePages<T extends QuantumDocumentElementTypes>(quantumDocument: UseQua
   }
 
   // Element Added/Removed
-  // watch(quantumDocument.elements, (value) => {
-  //   console.log('yoo, something changed')
-  //   updatePageCount()
-  // })
+  watch(quantumDocument.elements, (value) => {
+    updatePageCount()
+  })
 
   watchImmediate(
     () => quantumDocument.options.paperSize,

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -283,7 +283,6 @@ function useElementDrag<T extends QuantumDocumentElementTypes>(
       })
 
     document.querySelector('.content')?.addEventListener('scroll', function (e) {
-      console.log('scroll', e, e.target.scrollTop)
       if (e.target && dragging) {
         let scrollLeft = e.target.scrollLeft != 0 ? e.target.scrollLeft / quantumDocument.options.gridCellSize.x : 0
         let scrollTop = e.target.scrollTop != 0 ? e.target.scrollTop / quantumDocument.options.gridCellSize.y : 0

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -287,8 +287,10 @@ function useElementDrag<T extends QuantumDocumentElementTypes>(quantumDocument: 
 
     document.querySelector('.content')?.addEventListener('scroll', function (e) {
       if (e.target && dragging) {
-        let scrollLeft = e.target.scrollLeft != 0 ? e.target.scrollLeft / quantumDocument.options.gridCellSize.x : 0
-        let scrollTop = e.target.scrollTop != 0 ? e.target.scrollTop / quantumDocument.options.gridCellSize.y : 0
+        let scrollLeft =
+          (e.target as HTMLDivElement).scrollLeft != 0 ? (e.target as HTMLDivElement).scrollLeft / quantumDocument.options.gridCellSize.x : 0
+        let scrollTop =
+          (e.target as HTMLDivElement).scrollTop != 0 ? (e.target as HTMLDivElement).scrollTop / quantumDocument.options.gridCellSize.y : 0
         let delta = new Vector2(scrollLeft - previousScrollLeft, scrollTop - previousScrollTop)
         quantumDocument.moveSelectedElements(delta)
 
@@ -305,7 +307,7 @@ function useEvents<T extends QuantumDocumentElementTypes>(
   quantumDocument: UseQuantumDocument<T>,
   focusedElementCommands: Ref<ElementCommands | undefined>,
   grid: ReturnType<typeof useGrid>,
-  pages
+  pages: ReturnType<typeof usePages>
 ) {
   function createElementAtEvent(ev: InputEvent) {
     let elementType: string = ExpressionElementType.typeName
@@ -398,7 +400,7 @@ function useEvents<T extends QuantumDocumentElementTypes>(
 function usePages<T extends QuantumDocumentElementTypes>(quantumDocument: UseQuantumDocument<T>) {
   const pageCount = ref(1)
   const defaultSheetSize = 'A4'
-  const sheetSizes = {
+  const sheetSizes: any = {
     A3: { width: 297, height: 420 },
     A4: { width: 210, height: 297 },
     A5: { width: 148, height: 210 },

--- a/src/ui/QuantumDocument.vue
+++ b/src/ui/QuantumDocument.vue
@@ -257,51 +257,51 @@ function useElementDrag<T extends QuantumDocumentElementTypes>(quantumDocument: 
   let previousScrollLeft = 0
   let dragging = false
 
-  interact('.quantum-block')
-    .draggable({
-      ignoreFrom: '.quantum-element',
-      modifiers: [
-        interact.modifiers.snap({
-          targets: [interact.snappers.grid({ x: quantumDocument.options.gridCellSize.x, y: quantumDocument.options.gridCellSize.y })],
-          range: Infinity,
-          relativePoints: [{ x: 0, y: 0 }],
-          offset: 'parent',
-          // endOnly: true,
-        }),
-        interact.modifiers.restrict({
-          restriction: '.quantum-document',
-          elementRect: { top: 0, left: 0, bottom: 1, right: 1 },
-          // endOnly: true,
-        }),
-      ],
-      inertia: false,
-      autoScroll: {
-        container: document.querySelector('.content') as HTMLElement,
-        margin: 50,
-        distance: 5,
-        interval: 10,
-        speed: 500,
-      },
-      // autoScroll: false,
-    })
-    .on('down', (event) => {
-      dragging = true
-      let target = document.querySelector('.content') as HTMLElement
-      previousScrollLeft = target.scrollLeft
-      previousScrollTop = target.scrollTop
-    })
-    .on('dragmove', (event) => {
-      let delta = new Vector2(event.dx / quantumDocument.options.gridCellSize.x, event.dy / quantumDocument.options.gridCellSize.y)
-      quantumDocument.moveSelectedElements(delta)
-      // quantumDocument.moveSelectedElements(delta, pages.getPageLimits())
-      event.preventDefault()
-    })
-    .on('dragend', (event) => {
-      pages.updatePageCount()
-      dragging = false
-    })
-
   nextTick(function () {
+    interact('.quantum-block')
+      .draggable({
+        ignoreFrom: '.quantum-element',
+        modifiers: [
+          interact.modifiers.snap({
+            targets: [interact.snappers.grid({ x: quantumDocument.options.gridCellSize.x, y: quantumDocument.options.gridCellSize.y })],
+            range: Infinity,
+            relativePoints: [{ x: 0, y: 0 }],
+            offset: 'parent',
+            // endOnly: true,
+          }),
+          interact.modifiers.restrict({
+            restriction: '.quantum-document',
+            elementRect: { top: 0, left: 0, bottom: 1, right: 1 },
+            // endOnly: true,
+          }),
+        ],
+        inertia: false,
+        autoScroll: {
+          container: document.querySelector('.content') as HTMLElement,
+          margin: 50,
+          distance: 5,
+          interval: 10,
+          speed: 500,
+        },
+        // autoScroll: false,
+      })
+      .on('down', (event) => {
+        dragging = true
+        let target = document.querySelector('.content') as HTMLElement
+        previousScrollLeft = target.scrollLeft
+        previousScrollTop = target.scrollTop
+      })
+      .on('dragmove', (event) => {
+        let delta = new Vector2(event.dx / quantumDocument.options.gridCellSize.x, event.dy / quantumDocument.options.gridCellSize.y)
+        quantumDocument.moveSelectedElements(delta)
+        // quantumDocument.moveSelectedElements(delta, pages.getPageLimits())
+        event.preventDefault()
+      })
+      .on('dragend', (event) => {
+        pages.updatePageCount()
+        dragging = false
+      })
+
     document.querySelector('.content')?.addEventListener('scroll', function (e) {
       if (e.target && dragging) {
         let scrollLeft = (e.target as HTMLDivElement).scrollLeft

--- a/src/ui/icon.ts
+++ b/src/ui/icon.ts
@@ -1,7 +1,0 @@
-// ICON.ts
-import { createVNode } from 'vue'
-import * as $Icon from '@ant-design/icons-vue'
-export const Icon = (props: { icon: string }) => {
-  // const { icon } = props
-  return createVNode($Icon[props.icon])
-}

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -39,7 +39,6 @@ function useCasStatus() {
 
   return {
     casState,
-    // casIcon,
     setStatus,
     setReady,
     setLoading,

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -20,15 +20,6 @@ function useUIPreferences() {
 }
 
 function useCasStatus() {
-  const statusIcons = {
-    disconnected: 'ApiOutlined',
-    loading: 'LoadingOutlined',
-    ready: 'CalculatorOutlined',
-    error: 'WarningOutlined',
-  } as const
-
-  const casIcon = computed(() => statusIcons[casState.value])
-
   function setStatus(s: string) {
     casState.value = s
   }
@@ -48,7 +39,7 @@ function useCasStatus() {
 
   return {
     casState,
-    casIcon,
+    // casIcon,
     setStatus,
     setReady,
     setLoading,


### PR DESCRIPTION
 - Container scroll instead of entire window scroll.
   - ![image](https://user-images.githubusercontent.com/44987569/131774573-4bb089be-5358-4b09-a2ba-b2d8c16cc48a.png)
 - Multi-select & drag
   - Also, use already implemented document.ts `useElementSelection()` instead of hacky list of element IDs
 - Limit element movement when using arrow keys
 - Limit crosshair movement when using arrow keys
 - Factorial
   - ![image](https://user-images.githubusercontent.com/44987569/131774747-5039efdd-1097-4142-8633-b4c6e11b3a7b.png)
 - Only import used antd components
 - Only import used icons
 - Fix strange behavior when dragging components after scrolling
 - Pages are printable
